### PR TITLE
Add support for packaging firmware from proprietary archives 

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard-apq8074.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard-apq8074.bb
@@ -1,0 +1,21 @@
+# Specify location of the corresponding NON-HLOS.bin file by adding
+# NHLOS_URI:pn-firmware-qcom-dragonboard-apq8074 = "..."  to local.conf. Use
+# "file://" if the file is provided locally.
+
+DESCRIPTION = "QCOM Firmware for Dragonboard APQ8074 board"
+
+LICENSE = "CLOSED"
+
+# dragonboard8074 firmware is unsigned, so install into generic location
+FW_QCOM_NAME = "apq8074"
+
+FW_QCOM_LIST = "adsp.mbn mba.mbn modem.mbn wcnss.mbn"
+
+require recipes-bsp/firmware/firmware-qcom.inc
+require recipes-bsp/firmware/firmware-qcom-nhlos.inc
+
+SPLIT_FIRMWARE_PACKAGES = " \
+    linux-firmware-qcom-${FW_QCOM_NAME}-audio \
+    linux-firmware-qcom-${FW_QCOM_NAME}-modem \
+    linux-firmware-qcom-${FW_QCOM_NAME}-wifi \
+"

--- a/recipes-bsp/firmware/firmware-qcom-ifc6410.bb
+++ b/recipes-bsp/firmware/firmware-qcom-ifc6410.bb
@@ -1,0 +1,22 @@
+# Specify location of the corresponding NON-HLOS.bin file by adding
+# NHLOS_URI:pn-firmware-qcom-ifc6410 = "..."  to local.conf. Use "file://"
+# if the file is provided locally.
+
+DESCRIPTION = "QCOM Firmware for Inforce IFC6410 board"
+
+LICENSE = "CLOSED"
+
+# ifc6410 firmware is unsigned, so install into generic location
+FW_QCOM_NAME = "apq8064"
+
+FW_QCOM_LIST = "dsps.mbn gss.mbn q6.mbn wcnss.mbn"
+
+require recipes-bsp/firmware/firmware-qcom.inc
+require recipes-bsp/firmware/firmware-qcom-nhlos.inc
+
+SPLIT_FIRMWARE_PACKAGES = " \
+    linux-firmware-qcom-${FW_QCOM_NAME}-dsps \
+    linux-firmware-qcom-${FW_QCOM_NAME}-gss \
+    linux-firmware-qcom-${FW_QCOM_NAME}-q6 \
+    linux-firmware-qcom-${FW_QCOM_NAME}-wifi \
+"

--- a/recipes-bsp/firmware/firmware-qcom-ifc6560.bb
+++ b/recipes-bsp/firmware/firmware-qcom-ifc6560.bb
@@ -1,0 +1,27 @@
+# Specify location of the corresponding NON-HLOS.bin file by adding
+# NHLOS_URI:pn-firmware-qcom-ifc6560 = "..."  to local.conf. Use "file://"
+# if the file is provided locally.
+
+DESCRIPTION = "QCOM Firmware for Inforce IFC6560 board"
+
+LICENSE = "CLOSED"
+
+# ifc6560 isn't locked, so install firmware into generic location
+FW_QCOM_NAME = "sda660"
+
+FW_QCOM_LIST = "\
+    adsp.mbn \
+    cdsp.mbn \
+    mba.mbn modem.mbn modemuw.jsn \
+    venus.mbn \
+"
+
+require recipes-bsp/firmware/firmware-qcom.inc
+require recipes-bsp/firmware/firmware-qcom-nhlos.inc
+
+SPLIT_FIRMWARE_PACKAGES = "\
+    linux-firmware-qcom-${FW_QCOM_NAME}-audio \
+    linux-firmware-qcom-${FW_QCOM_NAME}-compute \
+    linux-firmware-qcom-${FW_QCOM_NAME}-modem \
+    linux-firmware-qcom-${FW_QCOM_NAME}-venus \
+"

--- a/recipes-bsp/firmware/firmware-qcom-nhlos.inc
+++ b/recipes-bsp/firmware/firmware-qcom-nhlos.inc
@@ -1,0 +1,60 @@
+# Handle NON-HLOS.bin unpacking in a generic way
+# Include the file to be able to dissect the image using handle_nonhlos_image()
+# If NHLOS_URI is defined, the image will be dissected automatically
+
+NHLOS_URI ??= ""
+
+# List all firmware files to be installed
+FW_QCOM_LIST ??= ""
+
+DEPENDS += "pil-squasher-native mtools-native"
+
+# Conditionally populate SRC_URI. We have to do it here rather than in python
+# script to let base.bbclass to pick up dependencies
+SRC_URI += "${NHLOS_URI}"
+
+handle_nonhlos_image() {
+    mkdir -p ${B}/firmware
+    mcopy -n -s -i "$1" ::/* ${B}/firmware/
+    for fw in ${B}/firmware/image/*.mdt ; do
+        pil-squasher ${B}/`basename $fw mdt`mbn $fw || exit 1
+    done
+}
+
+# If the URL is the file:// URI, the whole local path will be duplicated in the WORKDIR.
+# Otherwise we just need the last (filename) part of the path.
+def get_nhlos_path(path):
+    from urllib.parse import urlparse
+    if path == "":
+        return ""
+    url = urlparse(path)
+    if url.scheme == "file":
+        return url.path
+    return url.path.rsplit('/', 1)[1]
+
+do_compile:prepend() {
+    if [ -n "${NHLOS_URI}" ] ; then
+        handle_nonhlos_image ${WORKDIR}/${@get_nhlos_path(d.getVar("NHLOS_URI"))}
+    fi
+}
+
+do_install:prepend() {
+    install -d ${D}${FW_QCOM_PATH}
+
+    for fw in ${FW_QCOM_LIST} ; do
+        if [ -r ${B}/$fw ] ; then
+            install -m 0644 ${B}/$fw ${D}${FW_QCOM_PATH}
+        fi
+
+        if [ -r ${B}/firmware/image/$fw ] ; then
+            install -m 0644 ${B}/firmware/image/$fw ${D}${FW_QCOM_PATH}
+        fi
+    done
+}
+
+# If firmware files are not provided, do not download/package anything
+python () {
+    uri = d.getVar("NHLOS_URI")
+    if uri == "":
+        bb.warn("%s: not packaging NHLOS firmware. Please provide HNLOS_URI" % d.getVar("PN"))
+}

--- a/recipes-bsp/firmware/firmware-qcom-sm8350-hdk.bb
+++ b/recipes-bsp/firmware/firmware-qcom-sm8350-hdk.bb
@@ -1,0 +1,26 @@
+# Specify location of the corresponding NON-HLOS.bin file by adding
+# NHLOS_URI:pn-firmware-qcom-sm8350-hdk = "..."  to local.conf. Use "file://"
+# if the file is provided locally.
+
+DESCRIPTION = "QCOM Firmware for SM8350 HDK (aka HDK888) board"
+
+LICENSE = "CLOSED"
+
+FW_QCOM_NAME = "sm8350"
+
+FW_QCOM_LIST = "\
+    adsp.mbn adspr.jsn adspua.jsn battmgr.jsn \
+    cdsp.mbn cdspr.jsn \
+    modem.mbn modemr.jsn \
+    slpi.mbn slpir.jsn \
+"
+
+require recipes-bsp/firmware/firmware-qcom.inc
+require recipes-bsp/firmware/firmware-qcom-nhlos.inc
+
+SPLIT_FIRMWARE_PACKAGES = "\
+    linux-firmware-qcom-${FW_QCOM_NAME}-audio \
+    linux-firmware-qcom-${FW_QCOM_NAME}-compute \
+    linux-firmware-qcom-${FW_QCOM_NAME}-modem \
+    linux-firmware-qcom-${FW_QCOM_NAME}-sensors \
+"

--- a/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard-apq8074.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard-apq8074.bb
@@ -1,0 +1,10 @@
+SUMMARY = "Firmware packages for the Dragonboard APQ8074 board"
+
+inherit packagegroup
+
+RRECOMMENDS:${PN} += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a3xx', '', d)} \
+    linux-firmware-qcom-apq8074-audio \
+    linux-firmware-qcom-apq8074-modem \
+    linux-firmware-qcom-apq8074-wifi \
+"

--- a/recipes-bsp/packagegroups/packagegroup-firmware-ifc6410.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-ifc6410.bb
@@ -6,4 +6,9 @@ RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a3xx', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath6k firmware-ath6kl', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-ar3k', '', d)} \
+    firmware-qcom-ifc6410 \
+    linux-firmware-qcom-apq8064-dsps \
+    linux-firmware-qcom-apq8064-gss \
+    linux-firmware-qcom-apq8064-q6 \
+    linux-firmware-qcom-apq8064-wifi \
 "

--- a/recipes-bsp/packagegroups/packagegroup-firmware-ifc6560.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-ifc6560.bb
@@ -1,0 +1,14 @@
+SUMMARY = "Firmware packages for the IFC6560 board"
+
+inherit packagegroup
+
+RRECOMMENDS:${PN} += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
+    firmware-qcom-ifc6560 \
+    linux-firmware-qcom-sda660-audio \
+    linux-firmware-qcom-sda660-compute \
+    linux-firmware-qcom-sda660-modem \
+    linux-firmware-qcom-sda660-venus \
+"

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8350-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8350-hdk.bb
@@ -1,0 +1,15 @@
+SUMMARY = "Firmware packages for the SM8350-HDK (aka HDK888) board"
+
+inherit packagegroup
+
+RRECOMMENDS:${PN} += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
+    firmware-qcom-sm8350-hdk \
+    linux-firmware-qcom-sm8350-audio \
+    linux-firmware-qcom-sm8350-compute \
+    linux-firmware-qcom-sm8350-modem \
+    linux-firmware-qcom-sm8350-sensors \
+    linux-firmware-qcom-vpu-2.0 \
+"


### PR DESCRIPTION
Sometimes it's necessary to build the image using firmware files from vendor-provided `NON-HLOS.bin`, `proprietary.tar.gz` or `adreno.tar.gz` (e.g. see #366 ). Add include files and example recipes to build firmware for ifc6410 and ifc6560 boards.