### PR TITLE
firmware-nexus: fix firmware-nexus* dependencies

### DIFF
--- a/recipes-bsp/firmware-nexus/firmware-qcom-nexus.inc
+++ b/recipes-bsp/firmware-nexus/firmware-qcom-nexus.inc
@@ -15,7 +15,6 @@ do_extract() {
     tail -n +315 ${WORKDIR}/extract-qcom-${FW_QCOM_NAME}.sh | tar xzfv - -C ${S}
 }
 addtask extract after do_unpack before do_patch
-do_extract[deptask] = "do_populate_sysroot"
 
 do_compile() {
     for fw in ${S}/vendor/qcom/${FW_QCOM_NAME}/proprietary/*.mdt ; do

--- a/recipes-bsp/firmware-nexus/firmware-qcom-pixel.inc
+++ b/recipes-bsp/firmware-nexus/firmware-qcom-pixel.inc
@@ -10,7 +10,7 @@ PV = "${AOSP_BUILD}"
 
 require recipes-bsp/firmware/firmware-qcom.inc
 
-DEPENDS += "pil-squasher-native rust-android-sparse-native e2fsprogs-native qc-image-unpacker-native mtools-native"
+DEPENDS += "pil-squasher-native"
 
 VENDOR_IMG_SPARSE ?= "1"
 
@@ -50,7 +50,7 @@ do_extract() {
     fi
 }
 addtask extract after do_unpack before do_patch
-do_extract[deptask] = "do_populate_sysroot"
+do_extract[depends] += "rust-android-sparse-native:do_populate_sysroot e2fsprogs-native:do_populate_sysroot qc-image-unpacker-native:do_populate_sysroot mtools-native:do_populate_sysroot"
 
 do_compile() {
     for fw in ${B}/firmware/*.mdt ; do

--- a/recipes-bsp/firmware-nexus/firmware-qcom-radio.inc
+++ b/recipes-bsp/firmware-nexus/firmware-qcom-radio.inc
@@ -1,7 +1,9 @@
 FACTORY_NAME ?= "${FW_QCOM_NAME}"
 SRC_URI += "https://dl.google.com/dl/android/aosp/${FACTORY_NAME}-${AOSP_BUILD}-factory-${CHECKSUM_factory}.zip;name=factory"
 
-DEPENDS += "pil-squasher-native qc-image-unpacker-native mtools-native"
+DEPENDS += "pil-squasher-native qc-image-unpacker-native"
+
+do_extract[depends] += "mtools-native:do_populate_sysroot"
 
 do_extract:append() {
     mkdir -p ${B}/radio


### PR DESCRIPTION
Rework the recipe dependecies to work with the recent bitbake/OE changes. Provide explicit dependencies for the do_extract task so that the syroot is fully staged and populated, otherwise some of the tools might be missing from the native sysroot at the do_extract time.