### PR TITLE
README.md: meta-qcom takeover

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,25 +30,14 @@ for the implementation details.
 ## Contributing
 
 If you want to contribute changes, you can send Github pull requests at
-https://github.com/ndechesne/meta-qcom/pulls.
-
-Alternatively you can send patches to openembedded@lists.linaro.org, in which
-case, please: 
-
-* When creating patches, please use something like:
-
-`git format-patch -s --subject-prefix='meta-qcom][PATCH' origin`
-
-* When sending patches, please use something like:
-
-`git send-email --to openembedded@lists.linaro.org <generated patch>`
+https://github.com/Linaro/meta-qcom/pulls.
 
 You can discuss about this layer, on `#linaro` on FreeNode IRC network.
 
 ## Reporting issues
 
-Please report any issue on https://github.com/ndechesne/meta-qcom/issues
+Please report any issue on https://github.com/Linaro/meta-qcom/issues
 
 ## Maintainer(s)
 
-Nicolas Dechesne <nicolas.dechesne@linaro.org>
+Dmitry Baryshkov <dmitry.baryshkov@linaro.org>


### PR DESCRIPTION
- Fix the URL to point to github.com/Linaro/meta-qcom
- Change the maintainer of meta-qcom to me
- Remove the mailing list option to submit patches