### PR TITLE
xserver-xorg: drop the xshmfence PACKAGECONFIG

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
@@ -1,3 +1,3 @@
 # We want to use modesetting + glamor with mesa freedreno driver
 # http://bloggingthemonkey.blogspot.fr/2016/11/a-quick-note-for-usersdistros.html
-PACKAGECONFIG:append:qcom = "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', ' dri3 xshmfence glamor', '', d)}"
+PACKAGECONFIG:append:qcom = "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', ' dri3 glamor', '', d)}"


### PR DESCRIPTION
Remote the xshmfence PACKAGECONFIG, removed in oe-core while converting the recipe from autotools to meson.