### PR TITLE
qcom-armv7a: add unified machine for 32-bit Snapdragon devices

### DIFF
--- a/conf/machine/qcom-armv7a.conf
+++ b/conf/machine/qcom-armv7a.conf
@@ -1,0 +1,38 @@
+#@TYPE: Machine
+#@NAME: Qualcomm Snapdragon ARMv7-a (with Krait cores)
+#@DESCRIPTION: Unified 32-bit machine configuration for the devices with Qualcomm Snapdragon ARMv7-a based CPUs (S4 and later)
+#
+# Note: This machine targets Snapdragon S4 Plus/Pro/Prime and early (32-bit
+# ARM) models of Snapdragon 400/600/800 series SoCs.  It will most probably
+# work on Snapdragon S4 (MSM8x25, Cortex-A5 with VFPv4) or on 32-bit IPQ SoCs
+#
+# Do not use this machine for SDXnn modems or for Snapdragon S1/S2/S3.
+
+require conf/machine/include/qcom-common.inc
+
+# Krait is not Cortex-A15, but its features are close enough
+DEFAULTTUNE = "cortexa15thf-neon-vfpv4"
+require conf/machine/include/tune-cortexa15.inc
+
+# Android boot image settings
+QCOM_BOOTIMG_PAGE_SIZE = "2048"
+
+MACHINE_FEATURES = "alsa screen alsa bluetooth ext2 ext3 opengl usb usbhost usbgadget"
+
+KERNEL_IMAGETYPE ?= "zImage"
+KERNEL_DEVICETREE ?= " \
+    qcom-apq8064-asus-nexus7-flo.dtb \
+    qcom-apq8064-ifc6410.dtb \
+    qcom-apq8084-ifc6540.dtb \
+    qcom-msm8974-lge-nexus5-hammerhead.dtb \
+    qcom-msm8974-sony-xperia-castor.dtb \
+"
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'wireless-regdb-static', '', d)} \
+"
+
+SERIAL_CONSOLE ?= "115200 ttyMSM0"
+
+QCOM_BOOTIMG_ROOTFS ?= "PARTLABEL=userdata"


### PR DESCRIPTION
Follow the lead of qcom-armv8a and add a unified machine config to be used for all devices using late (S4 and early 400/600/800 series) 32-bit Qualcomm Snapdragon based devices.

Do not use this machine for SDXnn modems or for Snapdragon S1/S2/S3.