### PR TITLE
firmware-qcom-dragonboard410c: stop shipping firmware files

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard410c.inc
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard410c.inc
@@ -3,7 +3,7 @@ DESCRIPTION = "QCOM Firmware for DragonBoard 410c"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4d087ee0965cb059f1b2f9429e166f64"
 
-DEPENDS += "mtools-native pil-squasher-native"
+RRECOMMENDS_${PN} = "linux-firmware-qcom-apq8016-modem linux-firmware-qcom-apq8016-wifi"
 
 FW_QCOM_NAME = "apq8016"
 
@@ -14,18 +14,6 @@ S = "${WORKDIR}/linux-board-support-package-r${PV}"
 do_install() {
     install -d ${D}${FW_QCOM_PATH}
 
-    install -m 0644 ./proprietary-linux/wlan/prima/WCNSS_qcom_wlan_nv.bin \
-                 ${D}${FW_QCOM_PATH}/WCNSS_qcom_wlan_nv_sbc.bin
-
-    MTOOLS_SKIP_CHECK=1 mcopy -i ./bootloaders-linux/NON-HLOS.bin \
-    ::image/modem.* ::image/mba.mbn ::image/wcnss.* ${D}${FW_QCOM_PATH}
-
-    pil-squasher ${D}${FW_QCOM_PATH}/modem.mbn \
-                 ${D}${FW_QCOM_PATH}/modem.mdt
-
-    pil-squasher ${D}${FW_QCOM_PATH}/wcnss.mbn \
-                 ${D}${FW_QCOM_PATH}/wcnss.mdt
-
     install -d ${D}${sysconfdir}/
     install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}
 
@@ -35,19 +23,12 @@ do_install() {
                  ${D}${nonarch_base_libdir}/firmware/wlan/prima/
 
     install -d ${D}${FW_QCOM_BASE_PATH}/msm8916
-    for file in ${D}${FW_QCOM_PATH}/*.mbn ${D}${FW_QCOM_PATH}/*.mdt ${D}${FW_QCOM_PATH}/*.b*
+    for file in modem.mbn mba.mbn wcnss.mbn
     do
-        ln -s ../apq8016/$(basename $file) ${D}${FW_QCOM_BASE_PATH}/msm8916/
+        ln -s ../apq8016/$file ${D}${FW_QCOM_BASE_PATH}/msm8916/$file
+    done
+    for file in modem.mdt wcnss.mdt
+    do
+        ln -s ../apq8016/`basename $file .mdt`.mbn ${D}${FW_QCOM_BASE_PATH}/msm8916/$file
     done
 }
-
-FILES:${PN} += "/boot/modem_fsg"
-FILES:${PN}-split = "${FW_QCOM_BASE_PATH}/msm8916/*.mdt ${FW_QCOM_BASE_PATH}/msm8916/*.b*"
-
-SPLIT_FIRMWARE_PACKAGES = " \
-    linux-firmware-qcom-${FW_QCOM_NAME}-modem \
-    linux-firmware-qcom-${FW_QCOM_NAME}-modem-split \
-    linux-firmware-qcom-${FW_QCOM_NAME}-wifi \
-    linux-firmware-qcom-${FW_QCOM_NAME}-wifi-split \
-    ${PN}-split \
-"


### PR DESCRIPTION
As the corresponding firmware files have been merged to the linux-firmware archive and recipe, stop shipping actual firmware files. Provide just compatibility links for the historical kernel.