### PR TITLE
Update RB1/RB2 support

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb1.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb1.bb
@@ -6,6 +6,7 @@ RRECOMMENDS:${PN} += " \
     firmware-qcom-rb1 \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qcm2290-zap-shader', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-qcm2290-wifi ', '', d)} \
+    linux-firmware-lt9611uxc \
     linux-firmware-qcom-qcm2290-audio \
     linux-firmware-qcom-qcm2290-modem \
     linux-firmware-qcom-venus-6.0 \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb2.bb
@@ -6,6 +6,7 @@ RRECOMMENDS:${PN} += " \
     firmware-qcom-rb2 \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qrb4210-zap-shader', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-qrb4210-wifi', '', d)} \
+    linux-firmware-lt9611uxc \
     linux-firmware-qcom-qrb4210-audio \
     linux-firmware-qcom-qrb4210-compute \
     linux-firmware-qcom-qrb4210-modem \

--- a/recipes-kernel/linux/linux-linaro-qcomlt_6.4.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_6.4.bb
@@ -3,4 +3,4 @@
 
 require recipes-kernel/linux/linux-linaro-qcom.inc
 
-SRCREV = "c47c8d25d0645f96826a7856e86c39619c0b479c"
+SRCREV = "4301c7b4d507687fc2301edb4fcea76188e39396"


### PR DESCRIPTION
- Include lt9611uxc firmware into corresponding packagesgroups
- Bump 6.4 SRCREV to fix interconnects support on RB2 board (and also to bring GPU to the RB2 board).