### PR TITLE
Fix Adreno ZAP shader packaging

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-rb1_20230724-v1.bb
+++ b/recipes-bsp/firmware/firmware-qcom-rb1_20230724-v1.bb
@@ -48,10 +48,10 @@ do_install() {
 
 SPLIT_FIRMWARE_PACKAGES = " \
     ${PN}-dspso \
+    linux-firmware-qcom-${FW_QCOM_NAME}-adreno \
     linux-firmware-qcom-${FW_QCOM_NAME}-audio \
     linux-firmware-qcom-${FW_QCOM_NAME}-modem \
     linux-firmware-qcom-${FW_QCOM_NAME}-wifi \
-    linux-firmware-qcom-${FW_QCOM_NAME}-zap-shader \
     linux-firmware-ath10k-wlanmdsp-rb12 \
     linux-firmware-qcom-venus-6.0 \
 "

--- a/recipes-bsp/firmware/firmware-qcom-rb2_20230724-v1.bb
+++ b/recipes-bsp/firmware/firmware-qcom-rb2_20230724-v1.bb
@@ -43,9 +43,9 @@ RDEPENDS_linux-firmware-qcom-${FW_QCOM_NAME}-wifi += "linux-firmware-ath10k-wlan
 
 SPLIT_FIRMWARE_PACKAGES = " \
     ${PN}-dspso \
+    linux-firmware-qcom-${FW_QCOM_NAME}-adreno \
     linux-firmware-qcom-${FW_QCOM_NAME}-audio \
     linux-firmware-qcom-${FW_QCOM_NAME}-compute \
     linux-firmware-qcom-${FW_QCOM_NAME}-modem \
     linux-firmware-qcom-${FW_QCOM_NAME}-wifi \
-    linux-firmware-qcom-${FW_QCOM_NAME}-zap-shader \
 "

--- a/recipes-bsp/firmware/firmware-qcom.inc
+++ b/recipes-bsp/firmware/firmware-qcom.inc
@@ -20,6 +20,7 @@ RRECOMMENDS:${PN} += "${@ ' '.join(filter(lambda p: not p.endswith('-split'), d.
 
 # Default settings for several split packages
 FILES:${PN}-dspso += "${FW_QCOM_BASE_PATH}/*/*dspso.bin"
+FILES:linux-firmware-qcom-${FW_QCOM_NAME}-adreno = "${FW_QCOM_PATH}/*_zap.mbn"
 FILES:linux-firmware-qcom-${FW_QCOM_NAME}-audio = "${FW_QCOM_PATH}/adsp.mbn ${FW_QCOM_PATH}/adsp*.jsn"
 FILES:linux-firmware-qcom-${FW_QCOM_NAME}-audio-split = "${FW_QCOM_PATH}/adsp.mdt ${FW_QCOM_PATH}/adsp.b*"
 FILES:linux-firmware-qcom-${FW_QCOM_NAME}-compute = "${FW_QCOM_PATH}/cdsp.mbn ${FW_QCOM_PATH}/cdsp*.jsn"
@@ -34,7 +35,6 @@ FILES:linux-firmware-qcom-${FW_QCOM_NAME}-sensors-split = "${FW_QCOM_PATH}/slpi.
 FILES:linux-firmware-qcom-${FW_QCOM_NAME}-venus = "${FW_QCOM_PATH}/venus.mbn ${FW_QCOM_PATH}/vidc*"
 FILES:linux-firmware-qcom-${FW_QCOM_NAME}-wifi = "${FW_QCOM_PATH}/wcnss.mbn ${FW_QCOM_PATH}/wlanmdsp.mbn"
 FILES:linux-firmware-qcom-${FW_QCOM_NAME}-wifi-split = "${FW_QCOM_PATH}/wcnss.mdt ${FW_QCOM_PATH}/wcnss.b*"
-FILES:linux-firmware-qcom-${FW_QCOM_NAME}-zap-shader = "${FW_QCOM_PATH}/*_zap.mbn"
 
 python() {
     pn = d.getVar("PN")

--- a/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard820c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard820c.bb
@@ -4,7 +4,7 @@ inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
     firmware-qcom-dragonboard820c \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530 linux-firmware-qcom-apq8096-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     linux-firmware-qcom-apq8096-audio \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard845c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard845c.bb
@@ -4,7 +4,7 @@ inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
     firmware-qcom-dragonboard845c \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-sdm845-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-sdm845-modem', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca linux-firmware-qcom-sdm845-modem', '', d)} \
     linux-firmware-qcom-sdm845-audio \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb1.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb1.bb
@@ -4,7 +4,7 @@ inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
     firmware-qcom-rb1 \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qcm2290-zap-shader', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qcm2290-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-qcm2290-wifi ', '', d)} \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-qcm2290-audio \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb2.bb
@@ -4,7 +4,7 @@ inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
     firmware-qcom-rb2 \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qrb4210-zap-shader', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qrb4210-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-qrb4210-wifi', '', d)} \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-qrb4210-audio \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb5.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb5.bb
@@ -4,7 +4,7 @@ inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
     firmware-qcom-rb5 \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a650', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a650 linux-firmware-qcom-sm8250-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     linux-firmware-lt9611uxc \


### PR DESCRIPTION
In OE-core the Adreno packages were split into platform-dependent and platform-independent parts. Sync with these changes.