### PR TITLE
[honister] Fix linaro kernel URL

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcom.inc
+++ b/recipes-kernel/linux/linux-linaro-qcom.inc
@@ -15,7 +15,7 @@ SRCBRANCH = "release/qcomlt-${PV}"
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_LINARO_QCOM_GIT ?= "git://git.linaro.org/landing-teams/working/qualcomm/kernel.git;protocol=https"
+LINUX_LINARO_QCOM_GIT ?= "git://git.codelinaro.org/linaro/qcomlt/kernel.git;protocol=https"
 SRC_URI = "${LINUX_LINARO_QCOM_GIT};branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Linaro git trees have been moved from git.linaro.org to git.codelinaro.org.

This causes a build failure on honister branch:
```
ERROR: ExpansionError during parsing /oe/build/conf/../../layers/meta-qcom/recipes-kernel/linux/linux-linaro-qcomlt-dev.bb
Traceback (most recent call last):
  File "/oe/bitbake/lib/bb/fetch2/__init__.py", line 1196, in srcrev_internal_helper(ud=<bb.fetch2.FetchData object at 0x7fdc16989220>, d=<bb.data_smart.DataSmart object at 0x7fdc17913670>, name='default'):
         if srcrev == "AUTOINC":
    >        srcrev = ud.method.latest_revision(ud, d, name)
     
  File "/oe/bitbake/lib/bb/fetch2/__init__.py", line 1605, in Git.latest_revision(ud=<bb.fetch2.FetchData object at 0x7fdc16989220>, d=<bb.data_smart.DataSmart object at 0x7fdc17913670>, name='default'):
             except KeyError:
    >            revs[key] = rev = self._latest_revision(ud, d, name)
                 return rev
  File "/oe/bitbake/lib/bb/fetch2/git.py", line 715, in Git._latest_revision(ud=<bb.fetch2.FetchData object at 0x7fdc16989220>, d=<bb.data_smart.DataSmart object at 0x7fdc17913670>, name='default'):
             """
    >        output = self._lsremote(ud, d, "")
             # Tags of the form ^{} may not work, need to fallback to other form
  File "/oe/bitbake/lib/bb/fetch2/git.py", line 704, in Git._lsremote(ud=<bb.fetch2.FetchData object at 0x7fdc16989220>, d=<bb.data_smart.DataSmart object at 0x7fdc17913670>, search=''):
                     bb.fetch2.check_network_access(d, cmd, repourl)
    >            output = runfetchcmd(cmd, d, True)
                 if not output:
  File "/oe/bitbake/lib/bb/fetch2/__init__.py", line 913, in runfetchcmd(cmd='export PSEUDO_DISABLED=1; export PATH="/oe/layers/openembedded-core/scripts:/oe/build/tmp-rpb-glibc/work/sdx55_mtp-linaro-linux-gnueabi/linux-linaro-qcomlt-dev/fetcheravoidrecurse-fetcheravoidrecurse/recipe-sysroot-native/usr/bin/arm-linaro-linux-gnueabi:/oe/build/tmp-rpb-glibc/work/sdx55_mtp-linaro-linux-gnueabi/linux-linaro-qcomlt-dev/fetcheravoidrecurse-fetcheravoidrecurse/recipe-sysroot/usr/bin/crossscripts:/oe/build/tmp-rpb-glibc/work/sdx55_mtp-linaro-linux-gnueabi/linux-linaro-qcomlt-dev/fetcheravoidrecurse-fetcheravoidrecurse/recipe-sysroot-native/usr/sbin:/oe/build/tmp-rpb-glibc/work/sdx55_mtp-linaro-linux-gnueabi/linux-linaro-qcomlt-dev/fetcheravoidrecurse-fetcheravoidrecurse/recipe-sysroot-native/usr/bin:/oe/build/tmp-rpb-glibc/work/sdx55_mtp-linaro-linux-gnueabi/linux-linaro-qcomlt-dev/fetcheravoidrecurse-fetcheravoidrecurse/recipe-sysroot-native/sbin:/oe/build/tmp-rpb-glibc/work/sdx55_mtp-linaro-linux-gnueabi/linux-linaro-qcomlt-dev/fetcheravoidrecurse-fetcheravoidrecurse/recipe-sysroot-native/bin:/oe/bitbake/bin:/oe/build/tmp-rpb-glibc/hosttools"; export HOME="/home/tuxbake"; git -c core.fsyncobjectfiles=0 -c gc.autoDetach=false ls-remote https://git.linaro.org/landing-teams/working/qualcomm/kernel.git ', d=<bb.data_smart.DataSmart object at 0x7fdc16b1b340>, quiet=True, cleanup=[], log=None, workdir=None):
     
    >        raise FetchError(error_message)
     
bb.data_smart.ExpansionError: Failure expanding variable SRCPV, expression was ${@bb.fetch2.get_srcrev(d)} which triggered exception FetchError: Fetcher failure: Fetch command export PSEUDO_DISABLED=1; export PATH="/oe/layers/openembedded-core/scripts:/oe/build/tmp-rpb-glibc/work/sdx55_mtp-linaro-linux-gnueabi/linux-linaro-qcomlt-dev/fetcheravoidrecurse-fetcheravoidrecurse/recipe-sysroot-native/usr/bin/arm-linaro-linux-gnueabi:/oe/build/tmp-rpb-glibc/work/sdx55_mtp-linaro-linux-gnueabi/linux-linaro-qcomlt-dev/fetcheravoidrecurse-fetcheravoidrecurse/recipe-sysroot/usr/bin/crossscripts:/oe/build/tmp-rpb-glibc/work/sdx55_mtp-linaro-linux-gnueabi/linux-linaro-qcomlt-dev/fetcheravoidrecurse-fetcheravoidrecurse/recipe-sysroot-native/usr/sbin:/oe/build/tmp-rpb-glibc/work/sdx55_mtp-linaro-linux-gnueabi/linux-linaro-qcomlt-dev/fetcheravoidrecurse-fetcheravoidrecurse/recipe-sysroot-native/usr/bin:/oe/build/tmp-rpb-glibc/work/sdx55_mtp-linaro-linux-gnueabi/linux-linaro-qcomlt-dev/fetcheravoidrecurse-fetcheravoidrecurse/recipe-sysroot-native/sbin:/oe/build/tmp-rpb-glibc/work/sdx55_mtp-linaro-linux-gnueabi/linux-linaro-qcomlt-dev/fetcheravoidrecurse-fetcheravoidrecurse/recipe-sysroot-native/bin:/oe/bitbake/bin:/oe/build/tmp-rpb-glibc/hosttools"; export HOME="/home/tuxbake"; git -c core.fsyncobjectfiles=0 -c gc.autoDetach=false ls-remote https://git.linaro.org/landing-teams/working/qualcomm/kernel.git  failed with exit code 128, output:
fatal: unable to update url base from redirection:
  asked for: https://git.linaro.org/landing-teams/working/qualcomm/kernel.git/info/refs?service=git-upload-pack
   redirect: https://git.codelinaro.org/linaro/qcomlt/kernel?service=git-upload-pack

The variable dependency chain for the failure is: SRCPV -> PV -> WORKDIR -> S
```