### PR TITLE
sdx55: switch to main linux-linaro-qcoml kernel recipe

### DIFF
--- a/conf/machine/sdx55-mtp.conf
+++ b/conf/machine/sdx55-mtp.conf
@@ -16,5 +16,3 @@ UBINIZE_ARGS ?= "-m 4096 -p 256KiB -s 4096"
 # Use system partition for rootfs
 UBI_VOLNAME ?= "system"
 QCOM_BOOTIMG_ROOTFS ?= "ubi0:system"
-
-PREFERRED_PROVIDER_virtual/kernel = "linux-linaro-qcomlt-dev"

--- a/conf/machine/sdx55-telit-fn980.conf
+++ b/conf/machine/sdx55-telit-fn980.conf
@@ -18,5 +18,3 @@ UBI_VOLNAME ?= "system"
 QCOM_BOOTIMG_ROOTFS ?= "ubi0:system"
 
 SERIAL_CONSOLES = "921600;ttyMSM0"
-
-PREFERRED_PROVIDER_virtual/kernel = "linux-linaro-qcomlt-dev"

--- a/recipes-support/fastrpc/fastrpc_git.bb
+++ b/recipes-support/fastrpc/fastrpc_git.bb
@@ -1,4 +1,4 @@
-HOMEPAGE = "https://git.linaro.org/landing-teams/working/qualcomm/fastrpc.git"
+HOMEPAGE = "https://git.codelinaro.org/linaro/qcomlt/fastrpc.git"
 SUMMARY = "Qualcomm FastRPC applications and library"
 SECTION = "devel"
 
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/fastrpc_apps_user.c;beginline=1;endline=29;md5=f9
 
 SRCREV = "5a8320c46df8c0dbefe71d97a8273f417e8721f3"
 SRC_URI = "\
-    git://git.linaro.org/landing-teams/working/qualcomm/fastrpc.git;branch=automake;protocol=https \
+    git://git.codelinaro.org/linaro/qcomlt/fastrpc.git;branch=automake;protocol=https \
     file://0001-apps_std_fopen_with_env-account-for-domain-kinds-whe.patch \
     file://adsprpcd.service \
     file://cdsprpcd.service \


### PR DESCRIPTION
There is enough upstream support for sdx55, we no longer need to use a custom kernel recipe.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>
(cherry picked from commit 11feed5403870a8f4e90dc6cc221dd702128ef3a)