### PR TITLE
kernel: switch git url to codelinaro

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcom.inc
+++ b/recipes-kernel/linux/linux-linaro-qcom.inc
@@ -15,7 +15,7 @@ SRCBRANCH = "release/qcomlt-${PV}"
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_LINARO_QCOM_GIT ?= "git://git.linaro.org/landing-teams/working/qualcomm/kernel.git;protocol=https"
+LINUX_LINARO_QCOM_GIT ?= "git://git.codelinaro.org/linaro/qcomlt/kernel.git;protocol=https"
 SRC_URI = "${LINUX_LINARO_QCOM_GIT};branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git"

--- a/recipes-support/fastrpc/fastrpc_git.bb
+++ b/recipes-support/fastrpc/fastrpc_git.bb
@@ -1,4 +1,4 @@
-HOMEPAGE = "https://git.linaro.org/landing-teams/working/qualcomm/fastrpc.git"
+HOMEPAGE = "https://git.codelinaro.org/linaro/qcomlt/fastrpc.git"
 SUMMARY = "Qualcomm FastRPC applications and library"
 SECTION = "devel"
 
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/fastrpc_apps_user.c;beginline=1;endline=29;md5=f9
 
 SRCREV = "bc36c705c9b057ca880a423021d3c19f02edeadd"
 SRC_URI = "\
-    git://git.linaro.org/landing-teams/working/qualcomm/fastrpc.git;branch=automake;protocol=https \
+    git://git.codelinaro.org/linaro/qcomlt/fastrpc.git;branch=automake;protocol=https \
     file://0001-apps_std_fopen_with_env-account-for-domain-kinds-whe.patch \
     file://adsprpcd.service \
     file://cdsprpcd.service \


### PR DESCRIPTION
Linaro git trees have been moved from git.linaro.org to git.codelinaro.org.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>
(cherry picked from commit f6124d7878154c7f1307d3ed0abca5bdc17d3e1f)