### PR TITLE
Subject of Change: Changed Freenode IRC to Libera Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ for the implementation details.
 If you want to contribute changes, you can send Github pull requests at
 https://github.com/Linaro/meta-qcom/pulls.
 
-You can discuss about this layer, on `#linaro` on FreeNode IRC network.
+You can discuss about this layer, on `#linaro` on Libera Chat IRC network.
 
 ## Reporting issues
 


### PR DESCRIPTION
README.md needed update to reflect the move of #linaro IRC channel from Freenode to Libera Chat