### PR TITLE
CI: drop legacy machines support

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       host: ubuntu-20.04
       images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-rootfs-image cryptodev-module
-      machines: dragonboard-410c dragonboard-845c qrb5165-rb5 qcom-armv8a sdx55-mtp sa8155p-adp qcom-armv7a
+      machines: qcom-armv8a sdx55-mtp qcom-armv7a
       ref_type: branch
       ref: master
       branch: master
@@ -22,7 +22,7 @@ jobs:
     with:
       host: ubuntu-20.04
       images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-rootfs-image cryptodev-module
-      machines: dragonboard-410c dragonboard-845c qrb5165-rb5 qcom-armv8a sdx55-mtp sa8155p-adp qcom-armv7a
+      machines: qcom-armv8a sdx55-mtp qcom-armv7a
       ref_type: branch
       ref: kirkstone
       branch: kirkstone
@@ -34,7 +34,7 @@ jobs:
     with:
       host: ubuntu-20.04
       images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image cryptodev-module
-      machines: dragonboard-410c dragonboard-845c qrb5165-rb5 qcom-armv8a sa8155p-adp
+      machines: qcom-armv8a
       ref_type: branch
       ref: dunfell
       branch: dunfell

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -9,7 +9,7 @@ jobs:
     with:
       host: ubuntu-20.04
       images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-rootfs-image cryptodev-module
-      machines: dragonboard-410c dragonboard-845c qrb5165-rb5 qcom-armv8a sdx55-mtp sa8155p-adp qcom-armv7a
+      machines: qcom-armv8a sdx55-mtp qcom-armv7a
       ref: refs/pull/${{github.event.pull_request.number}}/merge
       branch: ${{github.base_ref}}
       url: ${{github.server_url}}/${{github.repository}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
     with:
       host: ubuntu-20.04
       images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-rootfs-image cryptodev-module
-      machines: dragonboard-410c dragonboard-845c qrb5165-rb5 qcom-armv8a sdx55-mtp sa8155p-adp qcom-armv7a
+      machines: qcom-armv8a sdx55-mtp qcom-armv7a
       ref: ${{github.sha}}
       ref_type: sha
       branch: ${{github.ref_name}}


### PR DESCRIPTION
Stop testing images for the legacy machines. The qcom-armv8a is used instead.