### PR TITLE
recipes-support: pd-mapper bump to rev 10997ba

### DIFF
--- a/recipes-support/pd-mapper/pd-mapper_git.bb
+++ b/recipes-support/pd-mapper/pd-mapper_git.bb
@@ -5,19 +5,17 @@ SECTION = "devel"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c5d4ab97bca4e843c5afdbf78aa5fdee"
 
-DEPENDS = "qrtr"
+DEPENDS = "qrtr xz"
 
 inherit systemd
 
-SRCREV = "d7fe25fa6eff2e62cf264544adee9e8ca830dc78"
+SRCREV = "10997ba7c43a3787a40b6b1b161408033e716374"
 SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https \
 "
 
 PV = "0.0+${SRCPV}"
 
 S = "${WORKDIR}/git"
-
-EXTRA_OEMAKE = "prefix=${prefix} bindir=${bindir} libdir=${libdir} includedir=${includedir} LDFLAGS='${LDFLAGS} -Wl,-lqrtr' CFLAGS='${CFLAGS}'"
 
 do_install () {
     oe_runmake install DESTDIR=${D} prefix=${prefix} servicedir=${systemd_unitdir}/system


### PR DESCRIPTION
https://github.com/andersson/pd-mapper moved ahead and has critical fixes for pd-mapper functionality. Updated the corresponding recipe (recipes-support/pd-mapper/pd-mapper_git.bb) to catch up these changes. 