### PR TITLE
read android device serial number from sysfs node

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/qcom/android-gadget-setup.machine
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/qcom/android-gadget-setup.machine
@@ -1,4 +1,4 @@
 manufacturer=Qualcomm
 model=`hostname`
-androidserial="$(sed -n -e '/androidboot.serialno/  s/.*androidboot.serialno=\([^ ]*\).*/\1/gp ' /proc/cmdline)"
+androidserial="$(sed 's/0x//' /sys/class/mmc_host/mmc0/mmc0:0001/serial)"
 [ -n "$androidserial" ] && serial="$androidserial"


### PR DESCRIPTION
read android serial number value from sysfs node
instead of kernel command line. Upstream boot managers
e.g., systemd-boot does not populate kernel command line
with parameter androidboot.serialno.

Reading serial number from sysfs node
/sys/devices/soc0/serial_number generalizes the approach
and makes it independent of bootloader that loads kernel.
