### PR TITLE
Efi boot support

### DIFF
--- a/classes/linux-qcom-bootimg.bbclass
+++ b/classes/linux-qcom-bootimg.bbclass
@@ -39,7 +39,7 @@ python do_qcom_img_deploy() {
     B = d.getVar("B")
     D = d.getVar("D")
     kernel_output_dir = d.getVar("KERNEL_OUTPUT_DIR")
-    kernel_imagedest = d.getVar("KERNEL_IMAGEDEST")
+    kernel_dtbdest = d.getVar("KERNEL_DTBDEST")
     kernel = os.path.join(B, "kernel-dtb")
     definitrd = os.path.join(B, "initrd.img")
     mkbootimg = os.path.join(d.getVar("STAGING_BINDIR_NATIVE"), "skales", "mkbootimg")
@@ -105,7 +105,7 @@ python do_qcom_img_deploy() {
         with open(kernel, 'wb') as wfd:
             with open(os.path.join(kernel_output_dir, kernel_name), 'rb') as rfd:
                 shutil.copyfileobj(rfd, wfd)
-            with open(os.path.join(D, kernel_imagedest, dtb), 'rb') as rfd:
+            with open(os.path.join(D, kernel_dtbdest, dtb), 'rb') as rfd:
                 shutil.copyfileobj(rfd, wfd)
 
         rootfs = getVarDTB("QCOM_BOOTIMG_ROOTFS")

--- a/classes/linux-qcom-bootimg.bbclass
+++ b/classes/linux-qcom-bootimg.bbclass
@@ -132,7 +132,7 @@ python do_qcom_img_deploy() {
 do_qcom_img_deploy[depends] += "skales-native:do_populate_sysroot"
 do_qcom_img_deploy[vardeps] = "QCOM_BOOTIMG_PAGE_SIZE QCOM_BOOTIMG_KERNEL_BASE KERNEL_CMDLINE_EXTRA QCOM_BOOTIMG_ROOTFS"
 
-addtask qcom_img_deploy after do_populate_sysroot do_packagedata bundle_initramfs before do_deploy
+addtask qcom_img_deploy after do_populate_sysroot do_packagedata do_bundle_initramfs before do_deploy
 
 # Setup sstate, see deploy.bbclass
 SSTATETASKS += "do_qcom_img_deploy"

--- a/classes/uki.bbclass
+++ b/classes/uki.bbclass
@@ -1,0 +1,90 @@
+# This bbclass repacks kernel image as a UKI (Unified Kernel Image)
+# Composed by
+#   - an UEFI stub, from systemd-boot
+#   - the kernel Image
+#   - an initramfs
+#   - other metadata like kernel cmdline
+
+DEPENDS:append = " \
+            systemd-boot-native \
+            python3-native \
+            python3-pefile-native \
+            "
+
+require conf/image-uefi.conf
+
+inherit python3native
+
+do_install[depends] += " \
+    systemd-boot:do_deploy \
+    "
+do_install[depends] += "${@ '${INITRAMFS_IMAGE}:do_image_complete' if d.getVar('INITRAMFS_IMAGE') else ''}"
+do_uki[dirs] = "${B}"
+do_install[postfuncs] += "do_uki"
+
+python do_uki() {
+    import glob
+    import subprocess
+
+    # Construct the ukify command
+    ukify_cmd = ("ukify build")
+
+    deploy_dir_image = d.getVar('DEPLOY_DIR_IMAGE')
+
+    # Ramdisk
+    if d.getVar('INITRAMFS_IMAGE'):
+        initrd_image = d.getVar('INITRAMFS_IMAGE') + "-" + d.getVar('MACHINE')
+        baseinitrd = os.path.join(d.getVar('INITRAMFS_DEPLOY_DIR_IMAGE'), initrd_image)
+        for img in (".cpio.gz", ".cpio.lz4", ".cpio.lzo", ".cpio.lzma", ".cpio.xz", ".cpio"):
+            if os.path.exists(baseinitrd + img):
+                initrd = baseinitrd + img
+                break
+        if not initrd:
+            bb.fatal("initrd= must be specified to create unified kernel image.")
+        ukify_cmd += " --initrd=%s" % initrd
+
+    # Kernel Image.
+    # Note: systemd-boot can't handle compressed kernel image.
+    kernel_image = d.getVar('B') + "/" + d.getVar('KERNEL_OUTPUT_DIR') + "/Image"
+    kernel_version = d.getVar('KERNEL_VERSION')
+    if not os.path.exists(kernel_image):
+        bb.fatal("linux= must be specified to create unified kernel image.")
+    ukify_cmd += " --linux=%s --uname %s" % (kernel_image, kernel_version)
+
+    # Kernel cmdline
+    cmdline = "%s" %(d.getVar('KERNEL_CMDLINE_EXTRA'))
+    ukify_cmd += " --cmdline='%s'" % (cmdline)
+
+    # Architecture
+    target_arch = d.getVar('EFI_ARCH')
+    ukify_cmd += " --efi-arch %s" % target_arch
+
+    # Stub
+    stub = "%s/linux%s.efi.stub" % (deploy_dir_image, target_arch)
+    if not os.path.exists(stub):
+        bb.fatal("stub must be specified to create unified kernel image %s" %stub)
+    ukify_cmd += " --stub %s" % stub
+
+    # Custom UKI name
+    output_dir = d.getVar('D') + "/" +  d.getVar('EFILINUXDIR')
+    os.makedirs(output_dir, exist_ok=True)
+    output = output_dir + "/" + d.getVar('EFILINUXIMG')
+    ukify_cmd += " --output=%s" % output
+
+    # Set env to determine where bitbake should look for dynamic libraries
+    env = os.environ.copy() # get the env variables
+    env['LD_LIBRARY_PATH'] = d.expand("${RECIPE_SYSROOT_NATIVE}/usr/lib/systemd:${LD_LIBRARY_PATH}")
+
+    # Run the ukify command
+    subprocess.check_call(ukify_cmd, env=env, shell=True)
+}
+
+# Support uki as a package
+python () {
+    if not bb.data.inherits_class('nopackages', d):
+        d.appendVar("PACKAGES", " ${KERNEL_PACKAGE_NAME}-uki")
+}
+
+FILES:${KERNEL_PACKAGE_NAME}-uki = " \
+    /${EFILINUXDIR}/${EFILINUXIMG} \
+"

--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -37,3 +37,19 @@ SERIAL_CONSOLES ?= "115200;ttyMSM0"
 # image.  All our boards (except db410c) have 2GiB and db410c has 1GiB of RAM,
 # so this image would fit.
 INITRAMFS_MAXSIZE = "393216"
+
+# Use systemd-boot as the EFI bootloader
+EFI_PROVIDER = "systemd-boot"
+
+# Install packages at root of ESP
+EFI_PREFIX = ""
+
+# Location of Kernel and dtb inside ESP
+EFILINUXDIR ?= "${EFI_PREFIX}EFI/Linux"
+EFIDTBDIR ?= "${EFI_PREFIX}dtb"
+
+# Unified Kernel Image (UKI) name
+EFILINUXIMG ?= "linux-${MACHINE}.efi"
+
+# Place dtb at EFIDTDIR to seamlessly package
+KERNEL_DTBDEST = "${EFIDTBDIR}"

--- a/recipes-core/systemd/systemd-boot-native_254.4.bb
+++ b/recipes-core/systemd/systemd-boot-native_254.4.bb
@@ -1,0 +1,15 @@
+require recipes-core/systemd/systemd.inc
+
+inherit native
+
+RRECOMMENDS:${PN} += "python3-pefile-native"
+
+COMPATIBLE_HOST = "(aarch64.*|arm.*|x86_64.*|i.86.*)-linux"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install () {
+	install -d ${D}${bindir}
+	install -m 0755 ${S}/src/ukify/ukify.py ${D}${bindir}/ukify
+}

--- a/recipes-kernel/images/esp-qcom-image.bb
+++ b/recipes-kernel/images/esp-qcom-image.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "EFI System Partition Image to boot Qualcomm boards"
+
+COMPATIBLE_HOST = '(x86_64.*|arm.*|aarch64.*)-(linux.*)'
+
+PACKAGE_INSTALL = " \
+    kernel-devicetree \
+    kernel-uki \
+    systemd-boot \
+    systemd-bootconf \
+"
+
+KERNELDEPMODDEPEND = ""
+KERNEL_DEPLOY_DEPEND = ""
+
+inherit image
+
+IMAGE_FSTYPES = "vfat"
+IMAGE_FSTYPES_DEBUGFS = ""
+
+LINGUAS_INSTALL = ""

--- a/recipes-kernel/linux/linux-linaro-qcom.inc
+++ b/recipes-kernel/linux/linux-linaro-qcom.inc
@@ -25,6 +25,7 @@ KERNEL_DEFCONFIG:arm ?= "${S}/arch/arm/configs/qcom_defconfig"
 KERNEL_CONFIG_FRAGMENTS += "${S}/kernel/configs/distro.config"
 
 inherit linux-qcom-bootimg
+inherit ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'uki', '', d)}
 
 kernel_conf_variable() {
 	sed -e "/CONFIG_$1[ =]/d;" -i ${B}/.config

--- a/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -8,6 +8,12 @@ SRC_URI:append:qcom = " \
     file://qcom.scc \
 "
 
+# For boot.img
 QCOM_BOOTIMG = ""
 QCOM_BOOTIMG:qcom = "linux-qcom-bootimg"
 inherit ${QCOM_BOOTIMG}
+
+# For UKI (linux.efi)
+QCOM_UKI = ""
+QCOM_UKI:qcom = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'uki', '', d)}"
+inherit ${QCOM_UKI}


### PR DESCRIPTION
To support systemd-boot as a boot manager, need to create an esp.bin with uki, uefi stub and other essential packaged into it. 
This is achieved in below patches.
1. Extend systemd-boot recipe through a bbappend to provide Ukify tool.
2. Add linux-qcom-efiimg bbclass to generate uki and in turn pack this uki into esp.bin
3. Inherit linux-qcom-efiimg bbclass in linux-yocto & linux-linaro recipes to generate esp.bin 