### PR TITLE
CI: use sdx55-mtp for kirkstone

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       host: ubuntu-20.04
       images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-rootfs-image cryptodev-module
-      machines: qcom-armv8a qcom-armv7a-modem qcom-armv7a
+      machines: qcom-armv8a sdx55-mtp qcom-armv7a
       ref_type: branch
       ref: kirkstone
       branch: kirkstone


### PR DESCRIPTION
The kirkstone branch wasn't migrated to qcom-armv7a-modem machine. Continue using sdx55-mtp for the CI on that branch.
