### PR TITLE
qcom-common.inc: make it less insisting on the default kernel

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -18,7 +18,7 @@ PREFERRED_PROVIDER_virtual/libgl ?= "mesa"
 PREFERRED_PROVIDER_virtual/libgles1 ?= "mesa"
 PREFERRED_PROVIDER_virtual/libgles2 ?= "mesa"
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-linaro-qcomlt"
+PREFERRED_PROVIDER_virtual/kernel ??= "linux-linaro-qcomlt"
 
 PREFERRED_PROVIDER_android-tools-conf = "android-tools-conf-configfs"
 


### PR DESCRIPTION
As we are transitioning to linux-yocto, make the life of machine config files easier and let qcom-common.inc be less insisting on the preferred kernel recipe.