### PR TITLE
android-gadget-setup: fix conditional argument to assign serial variable

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/qcom/android-gadget-setup.machine
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs/qcom/android-gadget-setup.machine
@@ -2,3 +2,4 @@ manufacturer=Qualcomm
 model=`hostname`
 androidserial="$(sed -n -e '/androidboot.serialno/  s/.*androidboot.serialno=\([^ ]*\).*/\1/gp ' /proc/cmdline)"
 [ -n "$androidserial" ] && serial="$androidserial"
+true


### PR DESCRIPTION
Change the conditional argument to check if androidserial is non-empty.

Initially we observed the following logs on boot-up as well as on running `systemctl restart android-tools-adbd`

Boot-up logs:
```txt
Apr 28 17:42:28 qcm6490 systemd[1]: Starting Android Debug Bridge...
Apr 28 17:42:28 qcm6490 systemd[1]: android-tools-adbd.service: Control process exited, code=exited, status=1/FAILURE
Apr 28 17:42:28 qcm6490 android-gadget-cleanup[518]: /usr/bin/android-gadget-cleanup: cd: line 7: can't cd to adb: No such file or directory
Apr 28 17:42:28 qcm6490 android-gadget-cleanup[518]: /usr/bin/android-gadget-cleanup: line 9: can't create UDC: Permission denied
Apr 28 17:42:28 qcm6490 android-gadget-cleanup[520]: killall: adbd: no process killed
Apr 28 17:42:28 qcm6490 android-gadget-cleanup[521]: umount: /dev/usb-ffs/adb: no mount point specified.
Apr 28 17:42:28 qcm6490 android-gadget-cleanup[522]: rm: cannot remove 'configs/c.1/ffs.usb0': No such file or directory
Apr 28 17:42:28 qcm6490 android-gadget-cleanup[524]: rmdir: failed to remove 'configs/c.1/strings/0x409': No such file or directory
Apr 28 17:42:28 qcm6490 android-gadget-cleanup[525]: rmdir: failed to remove 'configs/c.1': No such file or directory
Apr 28 17:42:28 qcm6490 android-gadget-cleanup[526]: rmdir: failed to remove 'functions/ffs.usb0': No such file or directory
```

Logs of `systemctl restart android-tools-adbd`
```txt
...
Apr 28 19:04:04 qcm6490 systemd[1]: Starting Android Debug Bridge...
...
Apr 28 19:04:04 qcm6490 android-gadget-cleanup[933]: killall: adbd: no process killed
Apr 28 19:04:04 qcm6490 android-gadget-cleanup[934]: umount: /dev/usb-ffs/adb: not mounted.
Apr 28 19:04:04 qcm6490 android-gadget-cleanup[936]: rm: cannot remove 'configs/c.1/ffs.usb0': No such file or directory
Apr 28 19:04:04 qcm6490 android-gadget-cleanup[937]: rmdir: failed to remove 'configs/c.1/strings/0x409': No such file or directory
Apr 28 19:04:04 qcm6490 android-gadget-cleanup[938]: rmdir: failed to remove 'configs/c.1': No such file or directory
Apr 28 19:04:04 qcm6490 android-gadget-cleanup[939]: rmdir: failed to remove 'functions/ffs.usb0': No such file or dirory
Apr 28 19:04:04 qcm6490 android-gadget-cleanup[940]: rmdir: failed to remove 'strings/0x409': No such file or directory
Apr 28 19:04:04 qcm6490 android-gadget-cleanup[941]: rmdir: failed to remove 'adb': No such file or directory
Apr 28 19:04:04 qcm6490 systemd[1]: android-tools-adbd.service: Control process exited, code=exited, status=1/FAILURE
Apr 28 19:04:04 qcm6490 systemd[1]: android-tools-adbd.service: Failed with result 'exit-code'.
...
Apr 28 19:04:04 qcm6490 systemd[1]: Stopped Android Debug Bridge.
...
(repeated 5 times)
```

To analyze any issue in the script, we ran `$ sh -x /usr/bin/android-gadget-setup`, and got the following

```txt
+ set -e
+ manufacturer=RPB
+ model='Android device'
+ serial=0123456789ABCDEF
+ '[' -r /etc/android-gadget-setup.machine ]
+ . /etc/android-gadget-setup.machine
+ manufacturer=Qualcomm
+ hostname
+ model=qcm6490
+ sed -n -e '/androidboot.serialno/  s/.*androidboot.serialno=\([^ ]*\).*/\1/gp ' /proc/cmdline
+ androidserial=
+ '[' -n  ]
```

Script abruptly stopped at `'[' -n  ]`, which is a syntax error. Script is running under `set -e` so any non-zero exit code in a command will abort the script. To fix the issue, we made the patch as provided in the commit.

After the patch, we saw the following output of `$ sh -x /usr/bin/android-gadget-setup`

```txt
+ set -e
+ manufacturer=RPB
+ model='Android device'
+ serial=0123456789ABCDEF
+ '[' -r /etc/android-gadget-setup.machine ]
+ . /etc/android-gadget-setup.machine
+ manufacturer=Qualcomm
+ hostname
+ model=qcm6490
+ sed -n -e '/androidboot.serialno/  s/.*androidboot.serialno=\([^ ]*\).*/\1/gp ' /proc/cmdline
+ androidserial=
+ '[' -n  ]
+ '[' -d /sys/kernel/config/usb_gadget ]
...
```

We can see that the script progressed past the stage of `[ -n ]`, confirming that the patch works. Further, `android-tools-adbd` started working and we could see the device visible in `adb devices` on host machine.