### PR TITLE
qcom-armv8a: fix the freshly introduced warnings

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -22,8 +22,11 @@ KERNEL_DEVICETREE ?= " \
     qcom/sm8450-hdk.dtb \
 "
 
-KERNEL_DEVICETREE:append:pn-linux-yocto += "qcom/qcm6490-idp.dtb"
-KERNEL_DEVICETREE:append:pn-linux-yocto += "qcom/qcm6490-rb3.dtb"
+# These DT are not upstreamed (yet) and currenty exist only as a patches against linux-yocto
+KERNEL_DEVICETREE:append:pn-linux-yocto = " \
+    qcom/qcm6490-idp.dtb \
+    qcom/qcm6490-rb3.dtb \
+"
 
 QCOM_BOOTIMG_PAGE_SIZE[apq8016-sbc] ?= "2048"
 QCOM_BOOTIMG_ROOTFS ?= "/dev/sda1"


### PR DESCRIPTION
Fix the warnings introduced by qcm6490-rb3g2 support:

WARNING: KERNEL_DEVICETREE:append:pn-linux-yocto += is not a recommended operator combination, please replace it. WARNING: KERNEL_DEVICETREE:append:pn-linux-yocto += is not a recommended operator combination, please replace it.

There is no need to use += together with the append.