### PR TITLE
Add Adreno firmware to the packaged firmware for several boards

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-adreno.inc
+++ b/recipes-bsp/firmware/firmware-qcom-adreno.inc
@@ -1,0 +1,40 @@
+# Handle Adreno firmware unpacking in a generic way
+# Include the file to be able to dissect the archive.
+# If ADRENO_URI is defined, the image will be dissected automatically
+# Handle fwpath=... as a path to Adreno firmware inside the archive
+
+ADRENO_URI ??= ""
+
+# Conditionally populate SRC_URI. We have to do it here rather than in python
+# script to let base.bbclass to pick up dependencies
+SRC_URI += "${@['', '${ADRENO_URI};subdir=adreno;name=adreno'][d.getVar('ADRENO_URI') != ''] }"
+
+# the file is unpacked to this dir, clean it up
+do_unpack[cleandirs] = "${WORKDIR}/adreno"
+
+DEPENDS += "pil-squasher-native"
+
+python () {
+    uri = d.getVar("ADRENO_URI")
+    if uri == "":
+        bb.warn("%s: not packaging ADRENO firmware. Please provide ADRENO_URI" % d.getVar("PN"))
+    else:
+        urldata = bb.fetch2.FetchData(d.getVar("ADRENO_URI"), d)
+        if "fwpath" in urldata.parm:
+            d.setVar("ADRENO_PATH", urldata.parm["fwpath"])
+        else:
+            d.setVar("ADRENO_PATH", "")
+}
+
+do_compile:append() {
+    if [ -n "${ADRENO_URI}" ] ; then
+        for fw in ${WORKDIR}/adreno/${ADRENO_PATH}/*_zap.mdt ; do
+            pil-squasher ${B}/`basename $fw mdt`mbn $fw || exit 1
+        done
+        for fw in ${FW_QCOM_LIST} ; do
+            if [ -r ${WORKDIR}/adreno/${ADRENO_PATH}/$fw ] ; then
+                cp ${WORKDIR}/adreno/${ADRENO_PATH}/$fw ${B}/
+            fi
+        done
+    fi
+}

--- a/recipes-bsp/firmware/firmware-qcom-ifc6560.bb
+++ b/recipes-bsp/firmware/firmware-qcom-ifc6560.bb
@@ -10,6 +10,7 @@ LICENSE = "CLOSED"
 FW_QCOM_NAME = "sda660"
 
 FW_QCOM_LIST = "\
+    a508_zap.mbn a512_zap.mbn \
     adsp.mbn \
     cdsp.mbn \
     mba.mbn modem.mbn modemuw.jsn \
@@ -18,8 +19,10 @@ FW_QCOM_LIST = "\
 
 require recipes-bsp/firmware/firmware-qcom.inc
 require recipes-bsp/firmware/firmware-qcom-nhlos.inc
+require recipes-bsp/firmware/firmware-qcom-adreno.inc
 
 SPLIT_FIRMWARE_PACKAGES = "\
+    linux-firmware-qcom-${FW_QCOM_NAME}-adreno \
     linux-firmware-qcom-${FW_QCOM_NAME}-audio \
     linux-firmware-qcom-${FW_QCOM_NAME}-compute \
     linux-firmware-qcom-${FW_QCOM_NAME}-modem \

--- a/recipes-bsp/firmware/firmware-qcom-sm8150-hdk.bb
+++ b/recipes-bsp/firmware/firmware-qcom-sm8150-hdk.bb
@@ -9,6 +9,7 @@ LICENSE = "CLOSED"
 FW_QCOM_NAME = "sm8150"
 
 FW_QCOM_LIST = "\
+    a640_zap.mbn a640_gmu.bin \
     adsp.mbn adspr.jsn adspua.jsn \
     cdsp.mbn cdspr.jsn \
     modem.mbn modemuw.jsn \
@@ -20,8 +21,13 @@ require recipes-bsp/firmware/firmware-qcom-nhlos.inc
 include recipes-bsp/firmware/firmware-qcom-adreno.inc
 
 SPLIT_FIRMWARE_PACKAGES = "\
+    linux-firmware-qcom-${FW_QCOM_NAME}-adreno \
     linux-firmware-qcom-${FW_QCOM_NAME}-audio \
     linux-firmware-qcom-${FW_QCOM_NAME}-compute \
     linux-firmware-qcom-${FW_QCOM_NAME}-modem \
     linux-firmware-qcom-${FW_QCOM_NAME}-sensors \
+    linux-firmware-qcom-adreno-a640 \
 "
+
+FILES:linux-firmware-qcom-adreno-a640 += "${FW_QCOM_PATH}/a640_gmu.bin"
+RDEPENDS:linux-firmware-qcom-adreno-a640 += "linux-firmware-qcom-adreno-a630"

--- a/recipes-bsp/firmware/firmware-qcom-sm8350-hdk.bb
+++ b/recipes-bsp/firmware/firmware-qcom-sm8350-hdk.bb
@@ -9,6 +9,7 @@ LICENSE = "CLOSED"
 FW_QCOM_NAME = "sm8350"
 
 FW_QCOM_LIST = "\
+    a660_zap.mbn a615_zap.mbn \
     adsp.mbn adspr.jsn adspua.jsn battmgr.jsn \
     cdsp.mbn cdspr.jsn \
     modem.mbn modemr.jsn \
@@ -17,8 +18,10 @@ FW_QCOM_LIST = "\
 
 require recipes-bsp/firmware/firmware-qcom.inc
 require recipes-bsp/firmware/firmware-qcom-nhlos.inc
+require recipes-bsp/firmware/firmware-qcom-adreno.inc
 
 SPLIT_FIRMWARE_PACKAGES = "\
+    linux-firmware-qcom-${FW_QCOM_NAME}-adreno \
     linux-firmware-qcom-${FW_QCOM_NAME}-audio \
     linux-firmware-qcom-${FW_QCOM_NAME}-compute \
     linux-firmware-qcom-${FW_QCOM_NAME}-modem \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-ifc6560.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-ifc6560.bb
@@ -3,7 +3,7 @@ SUMMARY = "Firmware packages for the IFC6560 board"
 inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530 linux-firmware-qcom-sda660-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
     firmware-qcom-ifc6560 \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8150-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8150-hdk.bb
@@ -3,6 +3,7 @@ SUMMARY = "Firmware packages for the SM8150-HDK (aka HDK855) board"
 inherit packagegroup
 
 RRECOMMENDS:${PN} += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a640 linux-firmware-qcom-sm8150-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
     firmware-qcom-sm8150-hdk \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8350-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8350-hdk.bb
@@ -7,6 +7,7 @@ RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
     firmware-qcom-sm8350-hdk \
+    linux-firmware-qcom-sm8350-adreno \
     linux-firmware-qcom-sm8350-audio \
     linux-firmware-qcom-sm8350-compute \
     linux-firmware-qcom-sm8350-modem \


### PR DESCRIPTION
Process archives with Adreno firmware (e.g. proprietary.tar.gz) to extract Adreno zap shaders (and GMU for sm8150).