### PR TITLE
mesa: stop requiring the XA tracker

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -5,7 +5,6 @@ PACKAGECONFIG_FREEDRENO = "\
     freedreno \
     tools \
     ${@bb.utils.contains('BBFILE_COLLECTIONS', 'openembedded-layer', 'freedreno-fdperf', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xa', '', d)} \
 "
 
 PACKAGECONFIG:append:qcom = "${PACKAGECONFIG_FREEDRENO}"


### PR DESCRIPTION
The XA tracker is only useful for the VMWare DDX driver. Drop it from PACKAGECONFIG_FREEDRENO. (xa tracker has been used for the xf86-video-freedreno driver, but it has been repalced by the generic modeswitching driver).