### PR TITLE
CI: update to actions/setup-python@v5

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
     - name: Install dependencies


### PR DESCRIPTION
Update CI to use actions/setup-python@v5 action to fix the GitHub warning.