### PR TITLE
qcom-armv7a: enable dragonboard-apq8074

### DIFF
--- a/conf/machine/qcom-armv7a.conf
+++ b/conf/machine/qcom-armv7a.conf
@@ -23,6 +23,7 @@ KERNEL_IMAGETYPE ?= "zImage"
 KERNEL_DEVICETREE ?= " \
     qcom/qcom-apq8064-asus-nexus7-flo.dtb \
     qcom/qcom-apq8064-ifc6410.dtb \
+    qcom/qcom-apq8074-dragonboard.dtb \
     qcom/qcom-apq8084-ifc6540.dtb \
     qcom/qcom-msm8974-lge-nexus5-hammerhead.dtb \
 "


### PR DESCRIPTION
Enable another board used for testing, APQ8074 DragonBoard.