### PR TITLE
linux-yocto: enable fuse to unbreak RPB images.

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_6.6.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_6.6.bb
@@ -3,4 +3,4 @@
 
 require recipes-kernel/linux/linux-linaro-qcom.inc
 
-SRCREV = "0cb2891e80a578ce862b23416850440a84276dd6"
+SRCREV = "13f77d4021f2afbd93b08735e0aa076828d52357"

--- a/recipes-kernel/linux/linux-yocto/bsp/qcom-armv7a/qcom-armv7a-standard.scc
+++ b/recipes-kernel/linux/linux-yocto/bsp/qcom-armv7a/qcom-armv7a-standard.scc
@@ -11,6 +11,7 @@ include qcom-armv7a.scc
 
 #include features/bluetooth/bluetooth.scc
 include features/cgroups/cgroups.scc
+include features/fuse/fuse.scc
 include features/transparent-hugepage/transparent-hugepage.cfg
 include features/usb-net/usb-net.scc
 

--- a/recipes-kernel/linux/linux-yocto/bsp/qcom-armv8a/qcom-armv8a-standard.scc
+++ b/recipes-kernel/linux/linux-yocto/bsp/qcom-armv8a/qcom-armv8a-standard.scc
@@ -11,6 +11,7 @@ include qcom-armv8a.scc
 
 #include features/bluetooth/bluetooth.scc
 include features/cgroups/cgroups.scc
+include features/fuse/fuse.scc
 include features/transparent-hugepage/transparent-hugepage.cfg
 include features/usb-net/usb-net.scc
 


### PR DESCRIPTION
Enable the fuse feature, used by the RPB images.