### PR TITLE
Add libcamera with CPU SoftISP into initramfs-test-full-image

### DIFF
--- a/recipes-multimedia/libcamera/libcamera_%.bbappend
+++ b/recipes-multimedia/libcamera/libcamera_%.bbappend
@@ -1,0 +1,9 @@
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSES/GPL-2.0-or-later.txt;md5=fed54355545ffd980b814dab4a3b312c \
+    file://LICENSES/LGPL-2.1-or-later.txt;md5=2a4f4fd2128ea2f65047ee63fbca9f68 \
+"
+
+SRCREV = "b2ef255295871fb6246d99bdd5b41aa65e3fc3b2"
+
+LIBCAMERA_PIPELINES = "simple"

--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -33,6 +33,7 @@ PACKAGE_INSTALL_openembedded-layer += " \
     gpsd-machine-conf \
     gps-utils \
     iozone3 \
+    libcamera \
     libgpiod \
     libgpiod-tools \
     lmbench \


### PR DESCRIPTION
This is the WIP branch for SoftISP debayering in libcamera.

At some stage in the hopefully not too distant future libcamera 0.3 upstream will merge this branch and we can probably drop the bbappend.

Either way it'd be nice to include libcamera and the "cam" util in the initramfs.

Once built a superficial example of usage is

`cam -c 1 --capture=10 --file`

Obviously more complex and interesting things can be done - all of the RPI camera stuff goes through libcamera so we very much want to follow this on the qcom side.