### PR TITLE
linux-yocto: enable various remotprocs for qcm6490 boards

### DIFF
--- a/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0001-UPSTREAM-arm64-dts-qcom-qcs6490-rb3gen2-Enable-adsp-.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0001-UPSTREAM-arm64-dts-qcom-qcs6490-rb3gen2-Enable-adsp-.patch
@@ -1,0 +1,42 @@
+From dce3ba85d15d0256d51c624ac82e6487f51c82bc Mon Sep 17 00:00:00 2001
+From: Bjorn Andersson <quic_bjorande@quicinc.com>
+Date: Tue, 26 Mar 2024 19:04:20 -0700
+Subject: [PATCH 1/3] UPSTREAM: arm64: dts: qcom: qcs6490-rb3gen2: Enable adsp
+ and cdsp
+
+Define firmware paths and enable the ADSP and CDSP remoteprocs.
+
+Signed-off-by: Bjorn Andersson <quic_bjorande@quicinc.com>
+Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Link: https://lore.kernel.org/r/20240326-rb3gen2-dp-connector-v2-3-a9f1bc32ecaf@quicinc.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git 3eb0b024decf99f917509db124f399dc47894075]
+---
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index 903ee11c98df..309e03bd2c9a 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -439,6 +439,16 @@ &qupv3_id_0 {
+ 	status = "okay";
+ };
+ 
++&remoteproc_adsp {
++        firmware-name = "qcom/qcs6490/adsp.mbn";
++        status = "okay";
++};
++
++&remoteproc_cdsp {
++        firmware-name = "qcom/qcs6490/cdsp.mbn";
++        status = "okay";
++};
++
+ &tlmm {
+ 	gpio-reserved-ranges = <32 2>, /* ADSP */
+ 			       <48 4>; /* NFC */
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0001-UPSTREAM-arm64-dts-qcom-sc7280-move-MPSS-and-WPSS-me.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0001-UPSTREAM-arm64-dts-qcom-sc7280-move-MPSS-and-WPSS-me.patch
@@ -1,0 +1,117 @@
+From 7b7acaa3a816e55742c461e2d5406d22de289568 Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca.weiss@fairphone.com>
+Date: Fri, 8 Dec 2023 16:08:00 +0100
+Subject: [PATCH 1/3] UPSTREAM: arm64: dts: qcom: sc7280*: move MPSS and WPSS
+ memory to dtsi
+
+It appears that all SC7280-based devices so far have mpss_mem and
+wpss_mem on the same reg with the same size.
+
+Also these memory regions are referenced already in sc7280.dtsi so
+that's where they should also be defined.
+
+Signed-off-by: Luca Weiss <luca.weiss@fairphone.com>
+Link: https://lore.kernel.org/r/20231208-sc7280-remoteprocs-v3-4-6aa394d33edf@fairphone.com
+[bjorn: delete-node &wpss_mem in qcs6490 rb3gen2, and qcm6490 idp]
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git 5037ca35ce42a962ea1b03895effd632a516b3b7]
+---
+ arch/arm64/boot/dts/qcom/qcm6490-idp.dts               |  1 +
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts           |  1 +
+ arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi     |  5 -----
+ arch/arm64/boot/dts/qcom/sc7280-herobrine-lte-sku.dtsi |  5 -----
+ .../arm64/boot/dts/qcom/sc7280-herobrine-wifi-sku.dtsi |  1 +
+ arch/arm64/boot/dts/qcom/sc7280.dtsi                   | 10 ++++++++++
+ 6 files changed, 13 insertions(+), 10 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+index 89e653c93ae8..7e792ec00243 100644
+--- a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
++++ b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+@@ -15,6 +15,7 @@
+ /delete-node/ &rmtfs_mem;
+ /delete-node/ &video_mem;
+ /delete-node/ &wlan_ce_mem;
++/delete-node/ &wpss_mem;
+ /delete-node/ &xbl_mem;
+ 
+ / {
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index d519f2064ea3..a6eb46f574e0 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -21,6 +21,7 @@
+ /delete-node/ &rmtfs_mem;
+ /delete-node/ &video_mem;
+ /delete-node/ &wlan_ce_mem;
++/delete-node/ &wpss_mem;
+ /delete-node/ &xbl_mem;
+ 
+ / {
+diff --git a/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi b/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
+index 323b7954b68c..349600297853 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
+@@ -38,11 +38,6 @@ venus_mem: memory@8b200000 {
+ 			reg = <0x0 0x8b200000 0x0 0x500000>;
+ 			no-map;
+ 		};
+-
+-		wpss_mem: memory@9ae00000 {
+-			reg = <0x0 0x9ae00000 0x0 0x1900000>;
+-			no-map;
+-		};
+ 	};
+ };
+ 
+diff --git a/arch/arm64/boot/dts/qcom/sc7280-herobrine-lte-sku.dtsi b/arch/arm64/boot/dts/qcom/sc7280-herobrine-lte-sku.dtsi
+index 203274c10532..b721a8546800 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280-herobrine-lte-sku.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280-herobrine-lte-sku.dtsi
+@@ -8,11 +8,6 @@
+ 
+ / {
+ 	reserved-memory {
+-		mpss_mem: memory@8b800000 {
+-			reg = <0x0 0x8b800000 0x0 0xf600000>;
+-			no-map;
+-		};
+-
+ 		mba_mem: memory@9c700000 {
+ 			reg = <0x0 0x9c700000 0x0 0x200000>;
+ 			no-map;
+diff --git a/arch/arm64/boot/dts/qcom/sc7280-herobrine-wifi-sku.dtsi b/arch/arm64/boot/dts/qcom/sc7280-herobrine-wifi-sku.dtsi
+index 2febd6126d4c..3ebc915f0dc2 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280-herobrine-wifi-sku.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280-herobrine-wifi-sku.dtsi
+@@ -7,5 +7,6 @@
+ 
+ /* WIFI SKUs save 256M by not having modem/mba/rmtfs memory regions defined. */
+ 
++/delete-node/ &mpss_mem;
+ /delete-node/ &remoteproc_mpss;
+ /delete-node/ &rmtfs_mem;
+diff --git a/arch/arm64/boot/dts/qcom/sc7280.dtsi b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+index ce8a7c1f12d5..0ea186be7b6a 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+@@ -152,6 +152,16 @@ ipa_fw_mem: ipa-fw@8b700000 {
+ 			no-map;
+ 		};
+ 
++		mpss_mem: mpss@8b800000 {
++			reg = <0x0 0x8b800000 0x0 0xf600000>;
++			no-map;
++		};
++
++		wpss_mem: wpss@9ae00000 {
++			reg = <0x0 0x9ae00000 0x0 0x1900000>;
++			no-map;
++		};
++
+ 		rmtfs_mem: rmtfs@9c900000 {
+ 			compatible = "qcom,rmtfs-mem";
+ 			reg = <0x0 0x9c900000 0x0 0x280000>;
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0002-UPSTREAM-arm64-dts-qcom-qcs6490-rb3gen2-Enable-vario.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0002-UPSTREAM-arm64-dts-qcom-qcs6490-rb3gen2-Enable-vario.patch
@@ -1,0 +1,50 @@
+From d8e17f697bcdf398ea177b6ac28756cfd3f6c586 Mon Sep 17 00:00:00 2001
+From: Komal Bajaj <quic_kbajaj@quicinc.com>
+Date: Wed, 17 Apr 2024 17:39:28 +0530
+Subject: [PATCH 2/3] UPSTREAM: arm64: dts: qcom: qcs6490-rb3gen2: Enable
+ various remoteprocs
+
+Enable the ADSP, CDSP and WPSS that are found on qcs6490-rb3gen2.
+
+Signed-off-by: Komal Bajaj <quic_kbajaj@quicinc.com>
+Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Link: https://lore.kernel.org/r/20240417120928.32344-3-quic_kbajaj@quicinc.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git ac6d35b9b74c113753bd266e01d6b853618a1e37]
+---
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index 309e03bd2c9a..36693977c4c1 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -17,7 +17,6 @@
+ #include "pmk8350.dtsi"
+ 
+ /delete-node/ &ipa_fw_mem;
+-/delete-node/ &remoteproc_mpss;
+ /delete-node/ &rmtfs_mem;
+ /delete-node/ &adsp_mem;
+ /delete-node/ &cdsp_mem;
+@@ -449,6 +448,16 @@ &remoteproc_cdsp {
+         status = "okay";
+ };
+ 
++&remoteproc_mpss {
++	firmware-name = "qcom/qcs6490/modem.mbn";
++	status = "okay";
++};
++
++&remoteproc_wpss {
++	firmware-name = "qcom/qcs6490/wpss.mbn";
++	status = "okay";
++};
++
+ &tlmm {
+ 	gpio-reserved-ranges = <32 2>, /* ADSP */
+ 			       <48 4>; /* NFC */
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0002-UPSTREAM-arm64-dts-qcom-sc7280-Add-ADSP-node.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0002-UPSTREAM-arm64-dts-qcom-sc7280-Add-ADSP-node.patch
@@ -1,0 +1,155 @@
+From c1f29760a2988d9d65cae0b88e8c0afb3f82c4de Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca.weiss@fairphone.com>
+Date: Fri, 8 Dec 2023 16:08:04 +0100
+Subject: [PATCH 2/3] UPSTREAM: arm64: dts: qcom: sc7280: Add ADSP node
+
+Add the node for the ADSP found on the SC7280 SoC, using standard
+Qualcomm firmware.
+
+Acked-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Signed-off-by: Luca Weiss <luca.weiss@fairphone.com>
+Link: https://lore.kernel.org/r/20231208-sc7280-remoteprocs-v3-8-6aa394d33edf@fairphone.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git 3658e411efcbb4df882763b09ae49efaa86585b4]
+---
+ arch/arm64/boot/dts/qcom/qcm6490-idp.dts      |  1 +
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts  |  1 +
+ .../boot/dts/qcom/sc7280-chrome-common.dtsi   |  5 --
+ arch/arm64/boot/dts/qcom/sc7280.dtsi          | 74 +++++++++++++++++++
+ 4 files changed, 76 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+index 7e792ec00243..db8ed29b8d81 100644
+--- a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
++++ b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+@@ -13,6 +13,7 @@
+ 
+ /delete-node/ &ipa_fw_mem;
+ /delete-node/ &rmtfs_mem;
++/delete-node/ &adsp_mem;
+ /delete-node/ &video_mem;
+ /delete-node/ &wlan_ce_mem;
+ /delete-node/ &wpss_mem;
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index a6eb46f574e0..6f774812bf91 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -19,6 +19,7 @@
+ /delete-node/ &ipa_fw_mem;
+ /delete-node/ &remoteproc_mpss;
+ /delete-node/ &rmtfs_mem;
++/delete-node/ &adsp_mem;
+ /delete-node/ &video_mem;
+ /delete-node/ &wlan_ce_mem;
+ /delete-node/ &wpss_mem;
+diff --git a/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi b/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
+index 349600297853..76f0a66b7dc1 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
+@@ -24,11 +24,6 @@
+ 
+ / {
+ 	reserved-memory {
+-		adsp_mem: memory@86700000 {
+-			reg = <0x0 0x86700000 0x0 0x2800000>;
+-			no-map;
+-		};
+-
+ 		camera_mem: memory@8ad00000 {
+ 			reg = <0x0 0x8ad00000 0x0 0x500000>;
+ 			no-map;
+diff --git a/arch/arm64/boot/dts/qcom/sc7280.dtsi b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+index 0ea186be7b6a..fff07fff5ef3 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+@@ -142,6 +142,11 @@ wlan_fw_mem: wlan-fw@80c00000 {
+ 			no-map;
+ 		};
+ 
++		adsp_mem: adsp@86700000 {
++			reg = <0x0 0x86700000 0x0 0x2800000>;
++			no-map;
++		};
++
+ 		video_mem: video@8b200000 {
+ 			reg = <0x0 0x8b200000 0x0 0x500000>;
+ 			no-map;
+@@ -3544,6 +3549,75 @@ qspi: spi@88dc000 {
+ 			status = "disabled";
+ 		};
+ 
++		remoteproc_adsp: remoteproc@3700000 {
++			compatible = "qcom,sc7280-adsp-pas";
++			reg = <0 0x03700000 0 0x100>;
++
++			interrupts-extended = <&pdc 6 IRQ_TYPE_LEVEL_HIGH>,
++					      <&adsp_smp2p_in 0 IRQ_TYPE_EDGE_RISING>,
++					      <&adsp_smp2p_in 1 IRQ_TYPE_EDGE_RISING>,
++					      <&adsp_smp2p_in 2 IRQ_TYPE_EDGE_RISING>,
++					      <&adsp_smp2p_in 3 IRQ_TYPE_EDGE_RISING>,
++					      <&adsp_smp2p_in 7 IRQ_TYPE_EDGE_RISING>;
++			interrupt-names = "wdog", "fatal", "ready", "handover",
++					  "stop-ack", "shutdown-ack";
++
++			clocks = <&rpmhcc RPMH_CXO_CLK>;
++			clock-names = "xo";
++
++			power-domains = <&rpmhpd SC7280_LCX>,
++					<&rpmhpd SC7280_LMX>;
++			power-domain-names = "lcx", "lmx";
++
++			memory-region = <&adsp_mem>;
++
++			qcom,qmp = <&aoss_qmp>;
++
++			qcom,smem-states = <&adsp_smp2p_out 0>;
++			qcom,smem-state-names = "stop";
++
++			status = "disabled";
++
++			glink-edge {
++				interrupts-extended = <&ipcc IPCC_CLIENT_LPASS
++							     IPCC_MPROC_SIGNAL_GLINK_QMP
++							     IRQ_TYPE_EDGE_RISING>;
++
++				mboxes = <&ipcc IPCC_CLIENT_LPASS
++						IPCC_MPROC_SIGNAL_GLINK_QMP>;
++
++				label = "lpass";
++				qcom,remote-pid = <2>;
++
++				fastrpc {
++					compatible = "qcom,fastrpc";
++					qcom,glink-channels = "fastrpcglink-apps-dsp";
++					label = "adsp";
++					qcom,non-secure-domain;
++					#address-cells = <1>;
++					#size-cells = <0>;
++
++					compute-cb@3 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <3>;
++						iommus = <&apps_smmu 0x1803 0x0>;
++					};
++
++					compute-cb@4 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <4>;
++						iommus = <&apps_smmu 0x1804 0x0>;
++					};
++
++					compute-cb@5 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <5>;
++						iommus = <&apps_smmu 0x1805 0x0>;
++					};
++				};
++			};
++		};
++
+ 		remoteproc_wpss: remoteproc@8a00000 {
+ 			compatible = "qcom,sc7280-wpss-pas";
+ 			reg = <0 0x08a00000 0 0x10000>;
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0003-UPSTREAM-arm64-dts-qcom-qcm6490-idp-Enable-various-r.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0003-UPSTREAM-arm64-dts-qcom-qcm6490-idp-Enable-various-r.patch
@@ -1,0 +1,51 @@
+From 22a42aa02019bb4d0c58209cd86d453421f82135 Mon Sep 17 00:00:00 2001
+From: Komal Bajaj <quic_kbajaj@quicinc.com>
+Date: Wed, 17 Apr 2024 17:39:27 +0530
+Subject: [PATCH 3/3] UPSTREAM: arm64: dts: qcom: qcm6490-idp: Enable various
+ remoteprocs
+
+Enable the ADSP, CDSP, MPSS and WPSS that are found on the SoC.
+
+Signed-off-by: Komal Bajaj <quic_kbajaj@quicinc.com>
+Link: https://lore.kernel.org/r/20240417120928.32344-2-quic_kbajaj@quicinc.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git 99a1c9eedf6098826c0f9dcbda2c23e5dad20244]
+---
+ arch/arm64/boot/dts/qcom/qcm6490-idp.dts | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+index f45573f80ca4..1cf23184fdfe 100644
+--- a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
++++ b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+@@ -445,6 +445,26 @@ &qupv3_id_0 {
+ 	status = "okay";
+ };
+ 
++&remoteproc_adsp {
++	firmware-name = "qcom/qcm6490/adsp.mbn";
++	status = "okay";
++};
++
++&remoteproc_cdsp {
++	firmware-name = "qcom/qcm6490/cdsp.mbn";
++	status = "okay";
++};
++
++&remoteproc_mpss {
++	firmware-name = "qcom/qcm6490/modem.mbn";
++	status = "okay";
++};
++
++&remoteproc_wpss {
++	firmware-name = "qcom/qcm6490/wpss.mbn";
++	status = "okay";
++};
++
+ &sdhc_1 {
+ 	non-removable;
+ 	no-sd;
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0003-UPSTREAM-arm64-dts-qcom-sc7280-Add-CDSP-node.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0003-UPSTREAM-arm64-dts-qcom-sc7280-Add-CDSP-node.patch
@@ -1,0 +1,235 @@
+From a68a4cfbbc06d92dcc7c762bd02731a530d7d161 Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca.weiss@fairphone.com>
+Date: Fri, 8 Dec 2023 16:08:05 +0100
+Subject: [PATCH 3/3] UPSTREAM: arm64: dts: qcom: sc7280: Add CDSP node
+
+Add the node for the ADSP found on the SC7280 SoC, using standard
+Qualcomm firmware.
+
+Remove the reserved-memory node from sc7280-chrome-common since CDSP is
+currently not used there.
+
+Acked-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Signed-off-by: Luca Weiss <luca.weiss@fairphone.com>
+Link: https://lore.kernel.org/r/20231208-sc7280-remoteprocs-v3-9-6aa394d33edf@fairphone.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git df62402e5ff9df1960622b4d7bc5dd43dc8e7b75]
+---
+ arch/arm64/boot/dts/qcom/qcm6490-idp.dts      |   1 +
+ arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts  |   1 +
+ .../boot/dts/qcom/sc7280-chrome-common.dtsi   |   6 +
+ arch/arm64/boot/dts/qcom/sc7280.dtsi          | 143 ++++++++++++++++++
+ 4 files changed, 151 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+index db8ed29b8d81..c2375d0a9b19 100644
+--- a/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
++++ b/arch/arm64/boot/dts/qcom/qcm6490-idp.dts
+@@ -14,6 +14,7 @@
+ /delete-node/ &ipa_fw_mem;
+ /delete-node/ &rmtfs_mem;
+ /delete-node/ &adsp_mem;
++/delete-node/ &cdsp_mem;
+ /delete-node/ &video_mem;
+ /delete-node/ &wlan_ce_mem;
+ /delete-node/ &wpss_mem;
+diff --git a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+index 6f774812bf91..e1bedce340fb 100644
+--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
++++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+@@ -20,6 +20,7 @@
+ /delete-node/ &remoteproc_mpss;
+ /delete-node/ &rmtfs_mem;
+ /delete-node/ &adsp_mem;
++/delete-node/ &cdsp_mem;
+ /delete-node/ &video_mem;
+ /delete-node/ &wlan_ce_mem;
+ /delete-node/ &wpss_mem;
+diff --git a/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi b/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
+index 76f0a66b7dc1..1a80bad4ae39 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
+@@ -17,6 +17,7 @@
+  * required by the setup for Chrome boards.
+  */
+ 
++/delete-node/ &cdsp_mem;
+ /delete-node/ &hyp_mem;
+ /delete-node/ &xbl_mem;
+ /delete-node/ &reserved_xbl_uefi_log;
+@@ -84,6 +85,11 @@ spi_flash: flash@0 {
+ 	};
+ };
+ 
++/* Currently not used */
++&remoteproc_cdsp {
++	/delete-property/ memory-region;
++};
++
+ &remoteproc_wpss {
+ 	compatible = "qcom,sc7280-wpss-pil";
+ 	clocks = <&gcc GCC_WPSS_AHB_BDG_MST_CLK>,
+diff --git a/arch/arm64/boot/dts/qcom/sc7280.dtsi b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+index fff07fff5ef3..308eb65d9c95 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+@@ -152,6 +152,11 @@ video_mem: video@8b200000 {
+ 			no-map;
+ 		};
+ 
++		cdsp_mem: cdsp@88f00000 {
++			reg = <0x0 0x88f00000 0x0 0x1e00000>;
++			no-map;
++		};
++
+ 		ipa_fw_mem: ipa-fw@8b700000 {
+ 			reg = <0 0x8b700000 0 0x10000>;
+ 			no-map;
+@@ -3786,6 +3791,144 @@ nsp_noc: interconnect@a0c0000 {
+ 			qcom,bcm-voters = <&apps_bcm_voter>;
+ 		};
+ 
++		remoteproc_cdsp: remoteproc@a300000 {
++			compatible = "qcom,sc7280-cdsp-pas";
++			reg = <0 0x0a300000 0 0x10000>;
++
++			interrupts-extended = <&intc GIC_SPI 578 IRQ_TYPE_LEVEL_HIGH>,
++					      <&cdsp_smp2p_in 0 IRQ_TYPE_EDGE_RISING>,
++					      <&cdsp_smp2p_in 1 IRQ_TYPE_EDGE_RISING>,
++					      <&cdsp_smp2p_in 2 IRQ_TYPE_EDGE_RISING>,
++					      <&cdsp_smp2p_in 3 IRQ_TYPE_EDGE_RISING>,
++					      <&cdsp_smp2p_in 7 IRQ_TYPE_EDGE_RISING>;
++			interrupt-names = "wdog", "fatal", "ready", "handover",
++					  "stop-ack", "shutdown-ack";
++
++			clocks = <&rpmhcc RPMH_CXO_CLK>;
++			clock-names = "xo";
++
++			power-domains = <&rpmhpd SC7280_CX>,
++					<&rpmhpd SC7280_MX>;
++			power-domain-names = "cx", "mx";
++
++			interconnects = <&nsp_noc MASTER_CDSP_PROC 0 &mc_virt SLAVE_EBI1 0>;
++
++			memory-region = <&cdsp_mem>;
++
++			qcom,qmp = <&aoss_qmp>;
++
++			qcom,smem-states = <&cdsp_smp2p_out 0>;
++			qcom,smem-state-names = "stop";
++
++			status = "disabled";
++
++			glink-edge {
++				interrupts-extended = <&ipcc IPCC_CLIENT_CDSP
++							     IPCC_MPROC_SIGNAL_GLINK_QMP
++							     IRQ_TYPE_EDGE_RISING>;
++				mboxes = <&ipcc IPCC_CLIENT_CDSP
++						IPCC_MPROC_SIGNAL_GLINK_QMP>;
++
++				label = "cdsp";
++				qcom,remote-pid = <5>;
++
++				fastrpc {
++					compatible = "qcom,fastrpc";
++					qcom,glink-channels = "fastrpcglink-apps-dsp";
++					label = "cdsp";
++					qcom,non-secure-domain;
++					#address-cells = <1>;
++					#size-cells = <0>;
++
++					compute-cb@1 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <1>;
++						iommus = <&apps_smmu 0x11a1 0x0420>,
++							 <&apps_smmu 0x1181 0x0420>;
++					};
++
++					compute-cb@2 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <2>;
++						iommus = <&apps_smmu 0x11a2 0x0420>,
++							 <&apps_smmu 0x1182 0x0420>;
++					};
++
++					compute-cb@3 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <3>;
++						iommus = <&apps_smmu 0x11a3 0x0420>,
++							 <&apps_smmu 0x1183 0x0420>;
++					};
++
++					compute-cb@4 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <4>;
++						iommus = <&apps_smmu 0x11a4 0x0420>,
++							 <&apps_smmu 0x1184 0x0420>;
++					};
++
++					compute-cb@5 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <5>;
++						iommus = <&apps_smmu 0x11a5 0x0420>,
++							 <&apps_smmu 0x1185 0x0420>;
++					};
++
++					compute-cb@6 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <6>;
++						iommus = <&apps_smmu 0x11a6 0x0420>,
++							 <&apps_smmu 0x1186 0x0420>;
++					};
++
++					compute-cb@7 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <7>;
++						iommus = <&apps_smmu 0x11a7 0x0420>,
++							 <&apps_smmu 0x1187 0x0420>;
++					};
++
++					compute-cb@8 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <8>;
++						iommus = <&apps_smmu 0x11a8 0x0420>,
++							 <&apps_smmu 0x1188 0x0420>;
++					};
++
++					/* note: secure cb9 in downstream */
++
++					compute-cb@11 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <11>;
++						iommus = <&apps_smmu 0x11ab 0x0420>,
++							 <&apps_smmu 0x118b 0x0420>;
++					};
++
++					compute-cb@12 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <12>;
++						iommus = <&apps_smmu 0x11ac 0x0420>,
++							 <&apps_smmu 0x118c 0x0420>;
++					};
++
++					compute-cb@13 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <13>;
++						iommus = <&apps_smmu 0x11ad 0x0420>,
++							 <&apps_smmu 0x118d 0x0420>;
++					};
++
++					compute-cb@14 {
++						compatible = "qcom,fastrpc-compute-cb";
++						reg = <14>;
++						iommus = <&apps_smmu 0x11ae 0x0420>,
++							 <&apps_smmu 0x118e 0x0420>;
++					};
++				};
++			};
++		};
++
+ 		usb_1: usb@a6f8800 {
+ 			compatible = "qcom,sc7280-dwc3", "qcom,dwc3";
+ 			reg = <0 0x0a6f8800 0 0x400>;
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-yocto/qcm6490-drivers/0001-UPSTREAM-remoteproc-qcom_q6v5_pas-Add-SC7280-ADSP-CD.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-drivers/0001-UPSTREAM-remoteproc-qcom_q6v5_pas-Add-SC7280-ADSP-CD.patch
@@ -1,0 +1,63 @@
+From 8922a712f9571f7bcf2a0a80a949f83d9d4e0655 Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca.weiss@fairphone.com>
+Date: Fri, 8 Dec 2023 16:08:02 +0100
+Subject: [PATCH] UPSTREAM: remoteproc: qcom_q6v5_pas: Add SC7280 ADSP, CDSP &
+ WPSS
+
+Add support for the ADSP, CDSP and WPSS remoteprocs found on the SC7280
+SoC using the q6v5-pas driver.
+
+This driver can be used on regular LA ("Linux Android") based releases,
+however the SC7280 ChromeOS devices need different driver support due to
+firmware differences.
+
+Reviewed-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Signed-off-by: Luca Weiss <luca.weiss@fairphone.com>
+Link: https://lore.kernel.org/r/20231208-sc7280-remoteprocs-v3-6-6aa394d33edf@fairphone.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git 300ed425dfa99f6926299ec196a1eedf05f47b21]
+---
+ drivers/remoteproc/qcom_q6v5_pas.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/drivers/remoteproc/qcom_q6v5_pas.c b/drivers/remoteproc/qcom_q6v5_pas.c
+index b5447dd2dd35..c97aeb1cff77 100644
+--- a/drivers/remoteproc/qcom_q6v5_pas.c
++++ b/drivers/remoteproc/qcom_q6v5_pas.c
+@@ -1150,6 +1150,22 @@ static const struct adsp_data sm8550_mpss_resource = {
+ 	.region_assign_idx = 2,
+ };
+ 
++static const struct adsp_data sc7280_wpss_resource = {
++	.crash_reason_smem = 626,
++	.firmware_name = "wpss.mdt",
++	.pas_id = 6,
++	.auto_boot = true,
++	.proxy_pd_names = (char*[]){
++		"cx",
++		"mx",
++		NULL
++	},
++	.load_state = "wpss",
++	.ssr_name = "wpss",
++	.sysmon_name = "wpss",
++	.ssctl_id = 0x19,
++};
++
+ static const struct of_device_id adsp_of_match[] = {
+ 	{ .compatible = "qcom,msm8226-adsp-pil", .data = &adsp_resource_init},
+ 	{ .compatible = "qcom,msm8953-adsp-pil", .data = &msm8996_adsp_resource},
+@@ -1162,7 +1178,10 @@ static const struct of_device_id adsp_of_match[] = {
+ 	{ .compatible = "qcom,qcs404-cdsp-pas", .data = &cdsp_resource_init },
+ 	{ .compatible = "qcom,qcs404-wcss-pas", .data = &wcss_resource_init },
+ 	{ .compatible = "qcom,sc7180-mpss-pas", .data = &mpss_resource_init},
++	{ .compatible = "qcom,sc7280-adsp-pas", .data = &sm8350_adsp_resource},
++	{ .compatible = "qcom,sc7280-cdsp-pas", .data = &sm6350_cdsp_resource},
+ 	{ .compatible = "qcom,sc7280-mpss-pas", .data = &mpss_resource_init},
++	{ .compatible = "qcom,sc7280-wpss-pas", .data = &sc7280_wpss_resource},
+ 	{ .compatible = "qcom,sc8180x-adsp-pas", .data = &sm8150_adsp_resource},
+ 	{ .compatible = "qcom,sc8180x-cdsp-pas", .data = &sm8150_cdsp_resource},
+ 	{ .compatible = "qcom,sc8180x-mpss-pas", .data = &sc8180x_mpss_resource},
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-yocto/qcm6490-dtsi/0001-UPSTREAM-dt-bindings-remoteproc-qcom-sc7180-pas-Fix-.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-dtsi/0001-UPSTREAM-dt-bindings-remoteproc-qcom-sc7180-pas-Fix-.patch
@@ -1,0 +1,41 @@
+From 4e924b53dad2b5b78cd5a045324c74aabe36c21b Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca.weiss@fairphone.com>
+Date: Fri, 8 Dec 2023 16:07:57 +0100
+Subject: [PATCH 1/5] UPSTREAM: dt-bindings: remoteproc: qcom: sc7180-pas: Fix
+ SC7280 MPSS PD-names
+
+The power domains for MPSS on SC7280 are actually named CX and MSS, and
+not CX and MX. Adjust the name which also aligns the bindings with the
+dts and fixes validation.
+
+Fixes: 8bb92d6fd0b3 ("dt-bindings: remoteproc: qcom,sc7180-pas: split into separate file")
+Acked-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Signed-off-by: Luca Weiss <luca.weiss@fairphone.com>
+Link: https://lore.kernel.org/r/20231208-sc7280-remoteprocs-v3-1-6aa394d33edf@fairphone.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git 9d598fab9731055638c6e9333c4f21aa0d174a48]
+---
+ .../devicetree/bindings/remoteproc/qcom,sc7180-pas.yaml    | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/remoteproc/qcom,sc7180-pas.yaml b/Documentation/devicetree/bindings/remoteproc/qcom,sc7180-pas.yaml
+index 689d5d535331..4b97eeb2782b 100644
+--- a/Documentation/devicetree/bindings/remoteproc/qcom,sc7180-pas.yaml
++++ b/Documentation/devicetree/bindings/remoteproc/qcom,sc7180-pas.yaml
+@@ -88,6 +88,13 @@ allOf:
+           maxItems: 2
+         power-domain-names:
+           maxItems: 2
++          items:
++            - description: CX power domain
++            - description: MSS power domain
++        power-domain-names:
++          items:
++            - const: cx
++            - const: mss
+ 
+ unevaluatedProperties: false
+ 
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-yocto/qcm6490-dtsi/0002-UPSTREAM-dt-bindings-remoteproc-qcom-sc7180-pas-Add-.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-dtsi/0002-UPSTREAM-dt-bindings-remoteproc-qcom-sc7180-pas-Add-.patch
@@ -1,0 +1,102 @@
+From 009646f64a3a967e6be558d1abdea97397aa938e Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca.weiss@fairphone.com>
+Date: Fri, 8 Dec 2023 16:08:01 +0100
+Subject: [PATCH 2/5] UPSTREAM: dt-bindings: remoteproc: qcom: sc7180-pas: Add
+ SC7280 compatibles
+
+Add the compatibles and constraints for the ADSP, CDSP and WPSS found on
+the SC7280 SoC.
+
+Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Signed-off-by: Luca Weiss <luca.weiss@fairphone.com>
+Link: https://lore.kernel.org/r/20231208-sc7280-remoteprocs-v3-5-6aa394d33edf@fairphone.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git 11eff1020440060c53d2261531432927c9fb4ee3]
+---
+ .../bindings/remoteproc/qcom,sc7180-pas.yaml  | 55 +++++++++++++++++++
+ 1 file changed, 55 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/remoteproc/qcom,sc7180-pas.yaml b/Documentation/devicetree/bindings/remoteproc/qcom,sc7180-pas.yaml
+index 4b97eeb2782b..c712db0e81c5 100644
+--- a/Documentation/devicetree/bindings/remoteproc/qcom,sc7180-pas.yaml
++++ b/Documentation/devicetree/bindings/remoteproc/qcom,sc7180-pas.yaml
+@@ -17,7 +17,10 @@ properties:
+   compatible:
+     enum:
+       - qcom,sc7180-mpss-pas
++      - qcom,sc7280-adsp-pas
++      - qcom,sc7280-cdsp-pas
+       - qcom,sc7280-mpss-pas
++      - qcom,sc7280-wpss-pas
+ 
+   reg:
+     maxItems: 1
+@@ -71,6 +74,41 @@ required:
+ 
+ allOf:
+   - $ref: /schemas/remoteproc/qcom,pas-common.yaml#
++  - if:
++      properties:
++        compatible:
++          enum:
++            - qcom,sc7180-adsp-pas
++    then:
++      properties:
++        interrupts:
++          maxItems: 5
++        interrupt-names:
++          maxItems: 5
++    else:
++      properties:
++        interrupts:
++          minItems: 6
++        interrupt-names:
++          minItems: 6
++
++  - if:
++      properties:
++        compatible:
++          enum:
++            - qcom,sc7180-adsp-pas
++            - qcom,sc7280-adsp-pas
++    then:
++      properties:
++        power-domains:
++          items:
++            - description: LCX power domain
++            - description: LMX power domain
++        power-domain-names:
++          items:
++            - const: lcx
++            - const: lmx
++
+   - if:
+       properties:
+         compatible:
+@@ -96,6 +134,23 @@ allOf:
+             - const: cx
+             - const: mss
+ 
++  - if:
++      properties:
++        compatible:
++          enum:
++            - qcom,sc7280-cdsp-pas
++            - qcom,sc7280-wpss-pas
++    then:
++      properties:
++        power-domains:
++          items:
++            - description: CX power domain
++            - description: MX power domain
++        power-domain-names:
++          items:
++            - const: cx
++            - const: mx
++
+ unevaluatedProperties: false
+ 
+ examples:
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-yocto/qcm6490-dtsi/0003-UPSTREAM-arm64-dts-qcom-sc7280-Use-WPSS-PAS-instead-.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-dtsi/0003-UPSTREAM-arm64-dts-qcom-sc7280-Use-WPSS-PAS-instead-.patch
@@ -1,0 +1,95 @@
+From 0d8cdf23b491a8bf9fbbd784c4f0179e77798def Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca.weiss@fairphone.com>
+Date: Fri, 8 Dec 2023 16:08:03 +0100
+Subject: [PATCH 3/5] UPSTREAM: arm64: dts: qcom: sc7280: Use WPSS PAS instead
+ of PIL
+
+The wpss-pil driver wants to manage too many resources that cannot be
+touched with standard Qualcomm firmware.
+
+Use the compatible from the PAS driver and move the ChromeOS-specific
+bits to sc7280-chrome-common.dtsi.
+
+Signed-off-by: Luca Weiss <luca.weiss@fairphone.com>
+Link: https://lore.kernel.org/r/20231208-sc7280-remoteprocs-v3-7-6aa394d33edf@fairphone.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git 0bcbf092560cc1c163156af67176cbb4b8a327f9]
+---
+ .../boot/dts/qcom/sc7280-chrome-common.dtsi   | 19 ++++++++++++++++++-
+ arch/arm64/boot/dts/qcom/sc7280.dtsi          | 15 +++------------
+ 2 files changed, 21 insertions(+), 13 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi b/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
+index 459ff877df54..323b7954b68c 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280-chrome-common.dtsi
+@@ -95,8 +95,25 @@ spi_flash: flash@0 {
+ };
+ 
+ &remoteproc_wpss {
+-	status = "okay";
++	compatible = "qcom,sc7280-wpss-pil";
++	clocks = <&gcc GCC_WPSS_AHB_BDG_MST_CLK>,
++		 <&gcc GCC_WPSS_AHB_CLK>,
++		 <&gcc GCC_WPSS_RSCP_CLK>,
++		 <&rpmhcc RPMH_CXO_CLK>;
++	clock-names = "ahb_bdg",
++		      "ahb",
++		      "rscp",
++		      "xo";
++
++	resets = <&aoss_reset AOSS_CC_WCSS_RESTART>,
++		 <&pdc_reset PDC_WPSS_SYNC_RESET>;
++	reset-names = "restart", "pdc_sync";
++
++	qcom,halt-regs = <&tcsr_1 0x17000>;
++
+ 	firmware-name = "ath11k/WCN6750/hw1.0/wpss.mdt";
++
++	status = "okay";
+ };
+ 
+ &scm {
+diff --git a/arch/arm64/boot/dts/qcom/sc7280.dtsi b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+index 7d0492c23d6d..96dc1f5b85c3 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+@@ -3536,7 +3536,7 @@ qspi: spi@88dc000 {
+ 		};
+ 
+ 		remoteproc_wpss: remoteproc@8a00000 {
+-			compatible = "qcom,sc7280-wpss-pil";
++			compatible = "qcom,sc7280-wpss-pas";
+ 			reg = <0 0x08a00000 0 0x10000>;
+ 
+ 			interrupts-extended = <&intc GIC_SPI 587 IRQ_TYPE_EDGE_RISING>,
+@@ -3548,12 +3548,8 @@ remoteproc_wpss: remoteproc@8a00000 {
+ 			interrupt-names = "wdog", "fatal", "ready", "handover",
+ 					  "stop-ack", "shutdown-ack";
+ 
+-			clocks = <&gcc GCC_WPSS_AHB_BDG_MST_CLK>,
+-				 <&gcc GCC_WPSS_AHB_CLK>,
+-				 <&gcc GCC_WPSS_RSCP_CLK>,
+-				 <&rpmhcc RPMH_CXO_CLK>;
+-			clock-names = "ahb_bdg", "ahb",
+-				      "rscp", "xo";
++			clocks = <&rpmhcc RPMH_CXO_CLK>;
++			clock-names = "xo";
+ 
+ 			power-domains = <&rpmhpd SC7280_CX>,
+ 					<&rpmhpd SC7280_MX>;
+@@ -3566,11 +3562,6 @@ remoteproc_wpss: remoteproc@8a00000 {
+ 			qcom,smem-states = <&wpss_smp2p_out 0>;
+ 			qcom,smem-state-names = "stop";
+ 
+-			resets = <&aoss_reset AOSS_CC_WCSS_RESTART>,
+-				 <&pdc_reset PDC_WPSS_SYNC_RESET>;
+-			reset-names = "restart", "pdc_sync";
+-
+-			qcom,halt-regs = <&tcsr_1 0x17000>;
+ 
+ 			status = "disabled";
+ 
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-yocto/qcm6490-dtsi/0004-UPSTREAM-arm64-dts-qcom-sc7280-Remove-unused-second-.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-dtsi/0004-UPSTREAM-arm64-dts-qcom-sc7280-Remove-unused-second-.patch
@@ -1,0 +1,53 @@
+From b4c0cfe346f7f16f5459cce528b7c65a5ffd4d2c Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca.weiss@fairphone.com>
+Date: Fri, 8 Dec 2023 16:07:58 +0100
+Subject: [PATCH 4/5] UPSTREAM: arm64: dts: qcom: sc7280: Remove unused second
+ MPSS reg
+
+The bindings for sc7280-mpss-pas neither expects a second reg nor a
+reg-names property, which is only required by the sc7280-mss-pil
+bindings.
+
+Move it to sc7280-herobrine-lte-sku.dtsi, the only place where that
+other compatible is used.
+
+Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Signed-off-by: Luca Weiss <luca.weiss@fairphone.com>
+Link: https://lore.kernel.org/r/20231208-sc7280-remoteprocs-v3-2-6aa394d33edf@fairphone.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git 419618bd90f6b2c3adec87beb0d62adfcae619eb]
+---
+ arch/arm64/boot/dts/qcom/sc7280-herobrine-lte-sku.dtsi | 2 ++
+ arch/arm64/boot/dts/qcom/sc7280.dtsi                   | 3 +--
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/sc7280-herobrine-lte-sku.dtsi b/arch/arm64/boot/dts/qcom/sc7280-herobrine-lte-sku.dtsi
+index 95505549adcc..203274c10532 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280-herobrine-lte-sku.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280-herobrine-lte-sku.dtsi
+@@ -33,6 +33,8 @@ &ipa {
+ 
+ &remoteproc_mpss {
+ 	compatible = "qcom,sc7280-mss-pil";
++	reg = <0 0x04080000 0 0x10000>, <0 0x04180000 0 0x48>;
++	reg-names = "qdsp6", "rmb";
+ 
+ 	clocks = <&gcc GCC_MSS_CFG_AHB_CLK>,
+ 		 <&gcc GCC_MSS_OFFLINE_AXI_CLK>,
+diff --git a/arch/arm64/boot/dts/qcom/sc7280.dtsi b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+index 96dc1f5b85c3..32fea294414e 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+@@ -2741,8 +2741,7 @@ adreno_smmu: iommu@3da0000 {
+ 
+ 		remoteproc_mpss: remoteproc@4080000 {
+ 			compatible = "qcom,sc7280-mpss-pas";
+-			reg = <0 0x04080000 0 0x10000>, <0 0x04180000 0 0x48>;
+-			reg-names = "qdsp6", "rmb";
++			reg = <0 0x04080000 0 0x10000>;
+ 
+ 			interrupts-extended = <&intc GIC_SPI 264 IRQ_TYPE_EDGE_RISING>,
+ 					      <&modem_smp2p_in 0 IRQ_TYPE_EDGE_RISING>,
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-yocto/qcm6490-dtsi/0005-UPSTREAM-arm64-dts-qcom-sc7280-Rename-reserved-memor.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-dtsi/0005-UPSTREAM-arm64-dts-qcom-sc7280-Rename-reserved-memor.patch
@@ -1,0 +1,108 @@
+From 928c38c36dbe67e5c84046024c5c02ecc48d95eb Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca.weiss@fairphone.com>
+Date: Fri, 8 Dec 2023 16:07:59 +0100
+Subject: [PATCH 5/5] UPSTREAM: arm64: dts: qcom: sc7280: Rename
+ reserved-memory nodes
+
+It was clarified a while ago that reserved-memory nodes shouldn't be
+called memory@ but should have a descriptive name. Update sc7280.dtsi to
+follow that.
+
+Reviewed-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Signed-off-by: Luca Weiss <luca.weiss@fairphone.com>
+Link: https://lore.kernel.org/r/20231208-sc7280-remoteprocs-v3-3-6aa394d33edf@fairphone.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git 6615713c10c974d13a13297e95acd304e419dfba]
+---
+ arch/arm64/boot/dts/qcom/sc7280.dtsi | 26 +++++++++++++-------------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/sc7280.dtsi b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+index 32fea294414e..ce8a7c1f12d5 100644
+--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
++++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
+@@ -91,68 +91,68 @@ reserved-memory {
+ 		#size-cells = <2>;
+ 		ranges;
+ 
+-		wlan_ce_mem: memory@4cd000 {
++		wlan_ce_mem: wlan-ce@4cd000 {
+ 			no-map;
+ 			reg = <0x0 0x004cd000 0x0 0x1000>;
+ 		};
+ 
+-		hyp_mem: memory@80000000 {
++		hyp_mem: hyp@80000000 {
+ 			reg = <0x0 0x80000000 0x0 0x600000>;
+ 			no-map;
+ 		};
+ 
+-		xbl_mem: memory@80600000 {
++		xbl_mem: xbl@80600000 {
+ 			reg = <0x0 0x80600000 0x0 0x200000>;
+ 			no-map;
+ 		};
+ 
+-		aop_mem: memory@80800000 {
++		aop_mem: aop@80800000 {
+ 			reg = <0x0 0x80800000 0x0 0x60000>;
+ 			no-map;
+ 		};
+ 
+-		aop_cmd_db_mem: memory@80860000 {
++		aop_cmd_db_mem: aop-cmd-db@80860000 {
+ 			reg = <0x0 0x80860000 0x0 0x20000>;
+ 			compatible = "qcom,cmd-db";
+ 			no-map;
+ 		};
+ 
+-		reserved_xbl_uefi_log: memory@80880000 {
++		reserved_xbl_uefi_log: xbl-uefi-res@80880000 {
+ 			reg = <0x0 0x80884000 0x0 0x10000>;
+ 			no-map;
+ 		};
+ 
+-		sec_apps_mem: memory@808ff000 {
++		sec_apps_mem: sec-apps@808ff000 {
+ 			reg = <0x0 0x808ff000 0x0 0x1000>;
+ 			no-map;
+ 		};
+ 
+-		smem_mem: memory@80900000 {
++		smem_mem: smem@80900000 {
+ 			reg = <0x0 0x80900000 0x0 0x200000>;
+ 			no-map;
+ 		};
+ 
+-		cpucp_mem: memory@80b00000 {
++		cpucp_mem: cpucp@80b00000 {
+ 			no-map;
+ 			reg = <0x0 0x80b00000 0x0 0x100000>;
+ 		};
+ 
+-		wlan_fw_mem: memory@80c00000 {
++		wlan_fw_mem: wlan-fw@80c00000 {
+ 			reg = <0x0 0x80c00000 0x0 0xc00000>;
+ 			no-map;
+ 		};
+ 
+-		video_mem: memory@8b200000 {
++		video_mem: video@8b200000 {
+ 			reg = <0x0 0x8b200000 0x0 0x500000>;
+ 			no-map;
+ 		};
+ 
+-		ipa_fw_mem: memory@8b700000 {
++		ipa_fw_mem: ipa-fw@8b700000 {
+ 			reg = <0 0x8b700000 0 0x10000>;
+ 			no-map;
+ 		};
+ 
+-		rmtfs_mem: memory@9c900000 {
++		rmtfs_mem: rmtfs@9c900000 {
+ 			compatible = "qcom,rmtfs-mem";
+ 			reg = <0x0 0x9c900000 0x0 0x280000>;
+ 			no-map;
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-yocto_6.6.bbappend
+++ b/recipes-kernel/linux/linux-yocto_6.6.bbappend
@@ -53,10 +53,16 @@ SRC_URI:append:qcom = " \
     file://generic-drivers/0001-FROMLIST-dma-heap-Add-proper-kref-handling-on-dma-bu.patch \
     file://generic-drivers/0002-FROMLIST-dma-heap-Provide-accessors-so-that-in-kerne.patch \
     file://qcm6490-drivers/0001-FROMGIT-phy-qcom-qmp-ufs-Add-Phy-Configuration-suppo.patch \
+    file://qcm6490-drivers/0001-UPSTREAM-remoteproc-qcom_q6v5_pas-Add-SC7280-ADSP-CD.patch \
     file://qcm6490-dtsi/0001-FROMLIST-arm64-dts-qcom-sc7280-Add-UFS-nodes-for-sc7.patch \
     file://qcm6490-dtsi/0001-PENDING-arm64-dts-qcom-sc7280-Add-interconnect-paths.patch \
     file://qcm6490-dtsi/0001-UPSTREAM-arm64-dts-qcom-sc7280-Move-video-firmware-t.patch \
     file://qcm6490-dtsi/0001-UPSTREAM-arm64-dts-qcom-Use-QCOM_SCM_VMID-defines-fo.patch \
+    file://qcm6490-dtsi/0001-UPSTREAM-dt-bindings-remoteproc-qcom-sc7180-pas-Fix-.patch \
+    file://qcm6490-dtsi/0002-UPSTREAM-dt-bindings-remoteproc-qcom-sc7180-pas-Add-.patch \
+    file://qcm6490-dtsi/0003-UPSTREAM-arm64-dts-qcom-sc7280-Use-WPSS-PAS-instead-.patch \
+    file://qcm6490-dtsi/0004-UPSTREAM-arm64-dts-qcom-sc7280-Remove-unused-second-.patch \
+    file://qcm6490-dtsi/0005-UPSTREAM-arm64-dts-qcom-sc7280-Rename-reserved-memor.patch \
     file://qcm6490-board-dts/0001-UPSTREAM-dt-bindings-arm-qcom-Add-QCM6490-Fairphone-.patch \
     file://qcm6490-board-dts/0002-UPSTREAM-dt-bindings-arm-qcom-Add-QCM6490-IDP-and-QC.patch \
     file://qcm6490-board-dts/0003-UPSTREAM-arm64-dts-qcom-Add-base-qcm6490-id.patch \
@@ -68,6 +74,9 @@ SRC_URI:append:qcom = " \
     file://qcm6490-board-dts/0003-BACKPORT-FROMLIST-arm64-dts-qcom-qcs6490-rb3gen2-Upd.patch \
     file://qcm6490-board-dts/0001-PENDING-arm64-dts-qcom-qcm6490-Add-UFS-nodes-for-IDP.patch \
     file://qcm6490-board-dts/0002-PENDING-arm64-dts-qcom-Add-UFS-nodes-for-qcs6490-rb3.patch \
+    file://qcm6490-board-dts/0001-UPSTREAM-arm64-dts-qcom-sc7280-move-MPSS-and-WPSS-me.patch \
+    file://qcm6490-board-dts/0002-UPSTREAM-arm64-dts-qcom-sc7280-Add-ADSP-node.patch \
+    file://qcm6490-board-dts/0003-UPSTREAM-arm64-dts-qcom-sc7280-Add-CDSP-node.patch \
     file://workarounds/0001-QCLINUX-arm64-dts-qcom-qcm6490-disable-sdhc1-for-ufs.patch \
     file://workarounds/0001-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch \
     file://workarounds/0002-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch \

--- a/recipes-kernel/linux/linux-yocto_6.6.bbappend
+++ b/recipes-kernel/linux/linux-yocto_6.6.bbappend
@@ -77,6 +77,9 @@ SRC_URI:append:qcom = " \
     file://qcm6490-board-dts/0001-UPSTREAM-arm64-dts-qcom-sc7280-move-MPSS-and-WPSS-me.patch \
     file://qcm6490-board-dts/0002-UPSTREAM-arm64-dts-qcom-sc7280-Add-ADSP-node.patch \
     file://qcm6490-board-dts/0003-UPSTREAM-arm64-dts-qcom-sc7280-Add-CDSP-node.patch \
+    file://qcm6490-board-dts/0001-UPSTREAM-arm64-dts-qcom-qcs6490-rb3gen2-Enable-adsp-.patch \
+    file://qcm6490-board-dts/0002-UPSTREAM-arm64-dts-qcom-qcs6490-rb3gen2-Enable-vario.patch \
+    file://qcm6490-board-dts/0003-UPSTREAM-arm64-dts-qcom-qcm6490-idp-Enable-various-r.patch \
     file://workarounds/0001-QCLINUX-arm64-dts-qcom-qcm6490-disable-sdhc1-for-ufs.patch \
     file://workarounds/0001-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch \
     file://workarounds/0002-PENDING-arm64-dts-qcom-Remove-voltage-vote-support-f.patch \


### PR DESCRIPTION
Add support for the ADSP, CDSP and WPSS remoteprocs found on SC7280 and enable various applicable remoteproc nodes for qcm6490-idp and qcs6490-rb3gen2.

This has dependency on PR#587.