### PR TITLE
Fix playback using WSA881x codecs

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_6.6.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_6.6.bb
@@ -3,4 +3,4 @@
 
 require recipes-kernel/linux/linux-linaro-qcom.inc
 
-SRCREV = "13f77d4021f2afbd93b08735e0aa076828d52357"
+SRCREV = "3565a579b97814fdc93898c9279f6a05106f9a14"

--- a/recipes-kernel/linux/linux-yocto/0001-ASoC-codecs-wsa881x-set-clk_stop_mode1-flag.patch
+++ b/recipes-kernel/linux/linux-yocto/0001-ASoC-codecs-wsa881x-set-clk_stop_mode1-flag.patch
@@ -1,0 +1,30 @@
+From 3565a579b97814fdc93898c9279f6a05106f9a14 Mon Sep 17 00:00:00 2001
+From: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
+Date: Fri, 19 Apr 2024 15:00:12 +0100
+Subject: [PATCH] ASoC: codecs: wsa881x: set clk_stop_mode1 flag
+
+WSA881x codecs do not retain the state while clock is stopped, so mark
+this with clk_stop_mode1 flag.
+
+Fixes: a0aab9e1404a ("ASoC: codecs: add wsa881x amplifier support")
+Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/broonie/sound.git/commit/?id=32ac501957e5f68fe0e4bf88fb4db75cfb8f6566]
+---
+ sound/soc/codecs/wsa881x.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sound/soc/codecs/wsa881x.c b/sound/soc/codecs/wsa881x.c
+index 3c025dabaf7a..1253695bebd8 100644
+--- a/sound/soc/codecs/wsa881x.c
++++ b/sound/soc/codecs/wsa881x.c
+@@ -1155,6 +1155,7 @@ static int wsa881x_probe(struct sdw_slave *pdev,
+ 	pdev->prop.sink_ports = GENMASK(WSA881X_MAX_SWR_PORTS, 0);
+ 	pdev->prop.sink_dpn_prop = wsa_sink_dpn_prop;
+ 	pdev->prop.scp_int1_mask = SDW_SCP_INT1_BUS_CLASH | SDW_SCP_INT1_PARITY;
++	pdev->prop.clk_stop_mode1 = true;
+ 	gpiod_direction_output(wsa881x->sd_n, !wsa881x->sd_n_val);
+ 
+ 	wsa881x->regmap = devm_regmap_init_sdw(pdev, &wsa881x_regmap_config);
+-- 
+2.43.0
+

--- a/recipes-kernel/linux/linux-yocto_6.6.bbappend
+++ b/recipes-kernel/linux/linux-yocto_6.6.bbappend
@@ -1,6 +1,7 @@
 
 SRC_URI:append:qcom = " \
     file://0001-arm64-dts-qcom-qcm2290-temporarily-disable-cluster-i.patch \
+    file://0001-ASoC-codecs-wsa881x-set-clk_stop_mode1-flag.patch \
     file://qca6390-driver/0001-dt-bindings-mfd-qcom-qca639x-add-binding-for-QCA639x.patch \
     file://qca6390-driver/0002-mfd-qca639x-add-support-for-QCA639x-powerup-sequence.patch \
     file://qca6390-driver/0003-mfd-qcom-qca639x-switch-to-platform-config-data.patch \


### PR DESCRIPTION
Backport patch fixing playback issues on the RB5 board, which uses WSA881x codec.