### PR TITLE
android-tools-conf-adbd-cmdline: Fix build-time warning about S being…

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-adbd-cmdline.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-adbd-cmdline.bb
@@ -3,6 +3,9 @@ SECTION = "console/utils"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 SRC_URI = " \
     file://50-adbd-cmdline.conf \
 "


### PR DESCRIPTION
… non-existent

android-tools-conf-adbd-cmdline doesn't have any checked out source files, which results in a warning regarding S not existing. Fix the warning by pointing S to ${WORKDIR}/sources and UNPACKDIR to ${S}.

The warning text:

WARNING: android-tools-conf-conf-adbd-cmdline-1.0-r0 do_unpack: android-tools-conf-conf-adbd-cmdline: the directory ${WORKDIR}/${BP} (<scrubbed>) pointed to by the S variable doesn't exist - please set S within the recipe to point to where the source has been unpacked to