### PR TITLE
Package firmware for ECS Liva QC710

### DIFF
--- a/recipes-bsp/firmware-woa/firmware-qcom-ecs-liva-qc710_200.0.10.0.bb
+++ b/recipes-bsp/firmware-woa/firmware-qcom-ecs-liva-qc710_200.0.10.0.bb
@@ -1,0 +1,39 @@
+DESCRIPTION = "Qualcomm Firmware for ECS Liva QC710 devices"
+
+LICENSE = "CLOSED"
+
+FW_QCOM_NAME = "ecs-liva-qc710"
+FW_QCOM_SUBDIR = "sc7180/ecs/qc710"
+WOA_SUBDIR = "ECS/7180_SHOEBOX"
+
+WOA_CABINETS = " \
+    qcdx7180.cab;name=dx \
+    qcipa7180.cab;name=ipa \
+    qcsubsys_ext_adsp7180.cab;name=adsp \
+    qcsubsys_ext_cdsp7180.cab;name=cdsp \
+    qcsubsys_ext_mpss7180.cab;name=mpss \
+    qcwlan7180.cab;name=wlan \
+"
+
+SRC_URI = " \
+    ${WOA_SRC_URI} \
+"
+
+SRC_URI[dx.sha256sum] = "4ca933e0ed1576608e0a62ed782f5ab9556aaee869f6dbba8d8c761a110c54e3"
+SRC_URI[ipa.sha256sum] = "b55886ffdad88caea19ce1fdd2268108832cc60a5374f1bb3a597be0dcf81246"
+SRC_URI[adsp.sha256sum] = "8d836758ed94b527b547982c6e52878f4f055ac87633598425694dac68c53052"
+SRC_URI[cdsp.sha256sum] = "656e7b42a5df43de4ec8a35acfb722d28b8cc2767546650bc5ce84b22cf6c0c1"
+SRC_URI[mpss.sha256sum] = "3d3d1ae4907f822bee7b889ee008e9a5f40c1d31b1a972ac32093fe45b5504e6"
+SRC_URI[wlan.sha256sum] = "2b296d3e0fabc6108d855172bd13b051af2d16e380c4a059a017d46003a99868"
+
+SPLIT_FIRMWARE_PACKAGES = "\
+    linux-firmware-qcom-${FW_QCOM_NAME}-adreno \
+    linux-firmware-qcom-${FW_QCOM_NAME}-audio \
+    linux-firmware-qcom-${FW_QCOM_NAME}-compute \
+    linux-firmware-qcom-${FW_QCOM_NAME}-ipa \
+    linux-firmware-qcom-${FW_QCOM_NAME}-modem \
+    linux-firmware-qcom-${FW_QCOM_NAME}-venus \
+    linux-firmware-qcom-${FW_QCOM_NAME}-wifi \
+"
+
+require firmware-woa.inc

--- a/recipes-bsp/images/initramfs-firmware-ecs-liva-qc710-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-ecs-liva-qc710-image.bb
@@ -1,0 +1,7 @@
+DESCRIPTION = "Tiny ramdisk image with ECS Liva QC710 devices firmware files"
+
+PACKAGE_INSTALL += " \
+    packagegroup-firmware-ecs-liva-qc710 \
+"
+
+require initramfs-firmware-image.inc

--- a/recipes-bsp/packagegroups/packagegroup-firmware-ecs-liva-qc710.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-ecs-liva-qc710.bb
@@ -1,0 +1,15 @@
+SUMMARY = "Firmware packages for the ECS LIVA QC710 devices"
+
+inherit packagegroup
+
+RRECOMMENDS:${PN} += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-ecs-liva-qc710-adreno', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-ecs-liva-qc710-wifi', '', d)} \
+    firmware-qcom-ecs-liva-qc710 \
+    linux-firmware-qcom-ecs-liva-qc710-audio \
+    linux-firmware-qcom-ecs-liva-qc710-compute \
+    linux-firmware-qcom-ecs-liva-qc710-ipa \
+    linux-firmware-qcom-ecs-liva-qc710-modem \
+    linux-firmware-qcom-ecs-liva-qc710-venus \
+"


### PR DESCRIPTION
ECS Liva QC710 is a devkit for SC7180 platform. Package firmware for the device.