### PR TITLE
Revert "android-tools-adbd-cmdline: Use UNPACKDIR instead of WORKDIR"

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-adbd-cmdline.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-adbd-cmdline.bb
@@ -9,7 +9,7 @@ SRC_URI = " \
 
 do_install() {
     install -d ${D}${systemd_unitdir}/system/android-tools-adbd.service.d
-    install -m 0644 ${UNPACKDIR}/50-adbd-cmdline.conf ${D}${systemd_unitdir}/system/android-tools-adbd.service.d
+    install -m 0644 ${WORKDIR}/50-adbd-cmdline.conf ${D}${systemd_unitdir}/system/android-tools-adbd.service.d
 }
 
 FILES:${PN} += " \


### PR DESCRIPTION
This reverts commit 53e55107662c788e2aba77d8bafc5d242d725772.