### PR TITLE
Add firmware package support for QCS6490 RB3Gen2

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -61,5 +61,6 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     packagegroup-firmware-dragonboard845c \
     packagegroup-firmware-rb1 \
     packagegroup-firmware-rb2 \
+    packagegroup-firmware-rb3gen2 \
     packagegroup-firmware-rb5 \
 "

--- a/recipes-bsp/firmware/firmware-qcom-rb3gen2_00039.2.bb
+++ b/recipes-bsp/firmware/firmware-qcom-rb3gen2_00039.2.bb
@@ -1,0 +1,71 @@
+DESCRIPTION = "QCOM Firmware for Qualcomm Robotics RB3Gen2 platform"
+
+LICENSE = "Proprietary"
+LICENSE_FILE = "LICENSE.qcom"
+
+# The license in the PDF format has been added next to the archive. This file is included in the SRC_URI and will be installed as part of the package for tracking purposes.
+# Both the PDF and TXT versions of the license contain same text.
+LICENSE_FILE_PDF = "NO.LOGIN.BINARY.LICENSE.QTI.pdf"
+
+LIC_FILES_CHKSUM = "file://${LICENSE_FILE};md5=164e3362a538eb11d3ac51e8e134294b \
+    file://${LICENSE_FILE_PDF};md5=e1d82f4252cf04ba59b8b9d0011e0180 \
+    "
+
+DEPENDS += "qca-swiss-army-knife-native"
+
+FW_D_NAME = "QCM6490_fw"
+
+SRC_URI = "\
+    https://artifacts.codelinaro.org/artifactory/qli-ci/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_${PV}/QCM6490.LE.1.0/common/build/ufs/bin/${FW_D_NAME}.zip;name=fw \
+    https://artifacts.codelinaro.org/ui/repos/tree/General/qli-ci/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_${PV}/QCM6490.LE.1.0/common/build/ufs/bin/${LICENSE_FILE_PDF};name=licensepdf \
+    https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/${LICENSE_FILE};name=license \
+    "
+
+SRC_URI[fw.sha256sum] = "7e5cec86d3222b1d6625d63776f6c278b41c585ace416f7589e3a99d3550c9eb"
+SRC_URI[licensepdf.sha256sum] = "447485ea2ea3e47a19f95ddb555ad6d6ca0562af7e1be69d9bf82169a7480c5c"
+SRC_URI[license.sha256sum] = "be904cd28cb292b80cdb6cf412ab0d9159d431671e987ad433c1f62e0988a9bc"
+
+FW_QCOM_NAME = "qcs6490"
+QCS6490_FW_SRC_PATH = "lib/firmware/qcom/qcs6490"
+
+ADRENO_URI = "https://artifacts.codelinaro.org/artifactory/qli-ci/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_${PV}/le-qclinux-1-0-r1/apps_proc/prebuilt_HY22/adreno_1.0_qcm6490.tar.gz;fwpath=lib/firmware"
+SRC_URI[adreno.sha256sum] = "efa9b263faef4e0891b2bc568f9ca18bab1c0e810311c764f0c59ebb5fb1ee39"
+
+S = "${UNPACKDIR}"
+
+require recipes-bsp/firmware/firmware-qcom.inc
+require recipes-bsp/firmware/firmware-qcom-adreno.inc
+
+do_compile:append() {
+    # Build board-2.bin needed by WiFi
+    ath11k-generate-board-2_json.sh ${UNPACKDIR}/${FW_D_NAME}/${QCS6490_FW_SRC_PATH} board-2.json
+    python3 "${STAGING_BINDIR_NATIVE}/ath11k-bdencoder" -c board-2.json -o board-2.bin
+}
+
+do_install:append() {
+    install -d ${D}${FW_QCOM_PATH}
+
+    install -m 0644 ${UNPACKDIR}/${FW_D_NAME}/${QCS6490_FW_SRC_PATH}/*dsp*.mbn ${D}${FW_QCOM_PATH}
+    install -m 0644 ${UNPACKDIR}/${FW_D_NAME}/${QCS6490_FW_SRC_PATH}/*dsp*.jsn ${D}${FW_QCOM_PATH}
+
+    install -m 0644  ${UNPACKDIR}/adreno/${ADRENO_PATH}/a660_zap.mbn ${D}${FW_QCOM_PATH}
+
+    install -d ${D}${nonarch_base_libdir}/firmware/ath11k/WCN6750/hw1.0/
+    install -m 0444 ${S}/board-2.bin ${D}${nonarch_base_libdir}/firmware/ath11k/WCN6750/hw1.0/board-2.bin
+
+    install -d ${D}${sysconfdir}/
+    install -m 0644 ${UNPACKDIR}/${LICENSE_FILE} ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}
+    install -m 0644 ${UNPACKDIR}/${LICENSE_FILE_PDF} ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}.pdf
+}
+
+SPLIT_FIRMWARE_PACKAGES = "\
+    linux-firmware-qcom-${FW_QCOM_NAME}-audio \
+    linux-firmware-qcom-${FW_QCOM_NAME}-compute \
+    linux-firmware-qcom-${FW_QCOM_NAME}-adreno \
+"
+
+inherit update-alternatives
+
+ALTERNATIVE:${PN} += "wcn6750-hw10-board-2"
+ALTERNATIVE_LINK_NAME[wcn6750-hw10-board-2] = "${nonarch_base_libdir}/firmware/ath11k/WCN6750/hw1.0/board-2.bin"
+ALTERNATIVE_PRIORITY = "100"

--- a/recipes-bsp/images/initramfs-firmware-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-image.bb
@@ -9,6 +9,7 @@ PACKAGE_INSTALL:qcom-armv8a = " \
     packagegroup-firmware-dragonboard845c \
     packagegroup-firmware-rb1 \
     packagegroup-firmware-rb2 \
+    packagegroup-firmware-rb3gen2 \
     packagegroup-firmware-rb5 \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'wireless-regdb-static', '', d)} \
 "

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb3gen2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb3gen2.bb
@@ -1,0 +1,13 @@
+SUMMARY = "Firmware packages for the RB3Gen2 platform"
+
+inherit packagegroup
+
+RRECOMMENDS:${PN} += " \
+    firmware-qcom-rb3gen2 \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    linux-firmware-qcom-qcs6490-audio \
+    linux-firmware-qcom-qcs6490-compute \
+    linux-firmware-qcom-vpu-2.0 \
+"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -8,9 +8,10 @@ inherit ${ALTERNATIVES_CLASS}
 ALTERNATIVE:${PN}-ath6k:qcom = "ar6004-hw13-bdata"
 ALTERNATIVE_LINK_NAME[ar6004-hw13-bdata] = "${nonarch_base_libdir}/firmware/ath6k/AR6004/hw1.3/bdata.bin"
 
-ALTERNATIVE:${PN}-ath11k:qcom += "wcn6855-hw20-amss wcn6855-hw20-m3 wcn6855-hw20-regdb wcn6855-hw20-notice wcn6855-hw20-board-2"
+ALTERNATIVE:${PN}-ath11k:qcom += "wcn6855-hw20-amss wcn6855-hw20-m3 wcn6855-hw20-regdb wcn6855-hw20-notice wcn6855-hw20-board-2 wcn6750-hw10-board-2"
 ALTERNATIVE_LINK_NAME[wcn6855-hw20-amss] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/amss.bin"
 ALTERNATIVE_LINK_NAME[wcn6855-hw20-m3] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/m3.bin"
 ALTERNATIVE_LINK_NAME[wcn6855-hw20-regdb] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/regdb.bin"
 ALTERNATIVE_LINK_NAME[wcn6855-hw20-notice] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/Notice.txt"
 ALTERNATIVE_LINK_NAME[wcn6855-hw20-board-2] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/board-2.bin"
+ALTERNATIVE_LINK_NAME[wcn6750-hw10-board-2] = "${nonarch_base_libdir}/firmware/ath11k/WCN6750/hw1.0/board-2.bin"


### PR DESCRIPTION
Add firmware package support for QCS6490 RB3Gen2 board.

This PR addresses the same purpose as the existing PR #551. However, due to limitations in writing to @kraparthy’s tree, we created this fresh PR. Please note that @kraparthy is no longer part of this project.