### PR TITLE
Support optional dtb loading via UKI

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -50,6 +50,10 @@ EFI_DTB_DIR ?= "${EFI_PREFIX}dtb"
 # Unified Kernel Image (UKI) name
 EFI_LINUX_IMG ?= "linux-${MACHINE}.efi"
 
+# dtb file to pack into UKI.
+# empty value would skip packing dtb.
+EFI_LINUX_IMG_DTB ?= ""
+
 # Place dtb at EFIDTDIR to seamlessly package
 KERNEL_DTBDEST = "${EFI_DTB_DIR}"
 

--- a/recipes-kernel/images/esp-qcom-image.bb
+++ b/recipes-kernel/images/esp-qcom-image.bb
@@ -1,9 +1,6 @@
 DESCRIPTION = "EFI System Partition Image to boot Qualcomm boards"
 
-COMPATIBLE_HOST = '(x86_64.*|arm.*|aarch64.*)-(linux.*)'
-
 PACKAGE_INSTALL = " \
-    kernel-devicetree \
     linux-qcom-uki \
     systemd-boot \
     systemd-bootconf \

--- a/recipes-kernel/images/linux-qcom-uki.bb
+++ b/recipes-kernel/images/linux-qcom-uki.bb
@@ -85,6 +85,13 @@ do_compile() {
     [ -f $stub ] && echo "Creating UKI with $stub" || bbfatal "$stub is not a valid stub to create UKI."
     ukify_cmd="$ukify_cmd --stub $stub"
 
+    # DTB
+    if [ -n "${EFI_LINUX_IMG_DTB}" ]; then
+        dtb="${DEPLOY_DIR_IMAGE}/${EFI_LINUX_IMG_DTB}"
+        [ -r "$dtb" ] && echo "Creating UKI with $dtb" || bbfatal "$dtb is not valid dtb to create UKI."
+        ukify_cmd="$ukify_cmd --devicetree=$dtb"
+    fi
+
     # Output
     mkdir -p "${B}${EFI_UKI_PATH}"
     output="${B}${EFI_UKI_PATH}/${EFI_LINUX_IMG}"


### PR DESCRIPTION
If a DTB is present in UKI, systemd-boot can override the default UEFI provided DTB. This provisioning of DTB via UKI allows the users to customize DTBs as per product needs without regenerating the firmware.