### PR TITLE
50-adbd-cmdline.conf: Change /var to /etc in ConditionPathExists

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-adbd-cmdline/50-adbd-cmdline.conf
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-adbd-cmdline/50-adbd-cmdline.conf
@@ -2,5 +2,5 @@
 # Clear all conditions
 ConditionPathExists=
 # And start if kernel adbd argument is provided or if the file exists
-ConditionPathExists=|/var/usb-debugging-enabled
+ConditionPathExists=|/etc/usb-debugging-enabled
 ConditionKernelCommandLine=|adbd


### PR DESCRIPTION
If android-tools-adbd.service service needs to be up upon boot, then the path assigned to ConditionPathExists must be present at boot time. This means that the path set to ConditionPathExists must be created at build time itself. /etc is a better place to keep files and directories that are created at build time rather than /var. /var is expected to house files that are created at run time.

Hence, change ConditionPathExists=|/var/usb-debugging-enabled to ConditionPathExists=|/etc/usb-debugging-enabled