### PR TITLE
linux-yocto: fix RB2 BlueTooth patch

### DIFF
--- a/recipes-kernel/linux/linux-yocto/qrb4210-dts/0002-arm64-dts-qcom-qrb4210-rb2-Enable-bluetooth.patch
+++ b/recipes-kernel/linux/linux-yocto/qrb4210-dts/0002-arm64-dts-qcom-qrb4210-rb2-Enable-bluetooth.patch
@@ -38,9 +38,9 @@ index 9738c0dacd58..33c312ae842e 100644
 -			regulator-max-microvolt = <2000000>;
 +			regulator-max-microvolt = <1800000>;
 +			regulator-allow-set-load;
+ 			regulator-always-on;
+ 			regulator-boot-on;
  		};
- 
- 		vreg_l10a_1p8: l10 {
 @@ -389,11 +391,13 @@ vreg_l15a_3p128: l15 {
  		vreg_l16a_1p3: l16 {
  			regulator-min-microvolt = <1704000>;


### PR DESCRIPTION
Make RB2 BlueTooth patch applicable again after the stable kernel bump.