### PR TITLE
qcom-common.inc: set PREFERRED_VERSION for linux-yocto

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -22,6 +22,8 @@ PREFERRED_PROVIDER_virtual/kernel ??= "linux-linaro-qcomlt"
 
 PREFERRED_PROVIDER_android-tools-conf = "android-tools-conf-configfs"
 
+PREFERRED_VERSION_linux-yocto ?= "6.6%"
+
 # Fastboot expects an ext4 image, which needs to be 4096 aligned
 IMAGE_FSTYPES ?= "ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT ?= "4096"


### PR DESCRIPTION
Now as the OE-Core has gained several linux-yocto versions, specify the preferred one.