### PR TITLE
packagegroups-firmware-*: use linux-firmware-qcom-vpu

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb3gen2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb3gen2.bb
@@ -9,5 +9,5 @@ RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     linux-firmware-qcom-qcs6490-audio \
     linux-firmware-qcom-qcs6490-compute \
-    linux-firmware-qcom-vpu-2.0 \
+    linux-firmware-qcom-vpu \
 "

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb5.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb5.bb
@@ -10,5 +10,5 @@ RRECOMMENDS:${PN} += " \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-sm8250-audio \
     linux-firmware-qcom-sm8250-compute \
-    linux-firmware-qcom-vpu-1.0 \
+    linux-firmware-qcom-vpu \
 "

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8350-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8350-hdk.bb
@@ -14,5 +14,5 @@ RRECOMMENDS:${PN} += " \
     linux-firmware-qcom-sm8350-ipa \
     linux-firmware-qcom-sm8350-modem \
     linux-firmware-qcom-sm8350-sensors \
-    linux-firmware-qcom-vpu-2.0 \
+    linux-firmware-qcom-vpu \
 "


### PR DESCRIPTION
Follow the OE-Core changes and use linux-firmware-qcom-vpu package instead of the (removed) l-l-qcom-vpu-1.0 and l-f-qcom-vpu-2.0.