### PR TITLE
Fix build error if INITRAMFS_IMAGE undefined

### DIFF
--- a/recipes-kernel/images/linux-qcom-uki.bb
+++ b/recipes-kernel/images/linux-qcom-uki.bb
@@ -18,6 +18,8 @@ require conf/image-uefi.conf
 
 KERNEL_VERSION = "${@get_kernelversion_file('${STAGING_KERNEL_BUILDDIR}')}"
 
+INITRAMFS_IMAGE ?= ''
+
 do_configure[depends] += " \
     systemd-boot:do_deploy \
     virtual/kernel:do_deploy \

--- a/recipes-kernel/images/linux-qcom-uki.bb
+++ b/recipes-kernel/images/linux-qcom-uki.bb
@@ -44,7 +44,7 @@ do_compile() {
     # Kernel Image
     # Note: systemd-boot can't handle compressed kernel image.
     kernel_image="${DEPLOY_DIR_IMAGE}/Image"
-    [ -f $kernel_image ] && echo "Creating UKI with $kernel_image" || bbfatal "No valid kernel image to create UKI. Add 'Image' to KERNEL_IMAGETYPES."
+    [ -f $kernel_image ] && echo "Creating UKI with $kernel_image" || bbfatal "$kernel_image is not valid to create UKI."
     ukify_cmd="$ukify_cmd --linux=$kernel_image"
 
     # Kernel version


### PR DESCRIPTION
Fixed below error in linux-qcom-uki.bb when INITRAMFS_IMAGE is undefined.

ERROR: Error for linux-qcom-uki.bb:do_configure[depends], dependency '${@ '${INITRAMFS_IMAGE}:do_image_complete' if d.getVar('INITRAMFS_IMAGE') else ''}' does not contain exactly one ':' character. Task 'depends' should be specified in the form 'packagename:task'
