### PR TITLE
initramfs-test-full-image: fix the musl condition

### DIFF
--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -27,7 +27,7 @@ PACKAGE_INSTALL:append:libc-glibc = " \
 
 # ncurses-terminfo is provided by oe-core layer, but it's only needed for gps (cgps), so include it here
 PACKAGE_INSTALL_openembedded-layer += " \
-    ${@['crash', ''][${TCLIBC} != 'musl']} \
+    ${@['crash', '']['${TCLIBC}' == 'musl']} \
     dhrystone \
     gpsd \
     gpsd-machine-conf \


### PR DESCRIPTION
Invert the condition so that crash gets disabled for musl systems.