### PR TITLE
CI: Enable building of the images with and without initramfs

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -32,6 +32,7 @@ env:
   DISTRO: poky
   TCLIBC: glibc musl
   KERNELS: linaro-qcomlt yocto
+  INITRAMFS: initramfs-rootfs-image ~
 
 jobs:
   build:
@@ -72,6 +73,7 @@ jobs:
 
         for tclibc in ${TCLIBC}; do
         for kernel in ${KERNELS}; do
+        for initramfs in ${INITRAMFS}; do
         cat << EOF >> plan.yaml
         ${tclibc}-${kernel}: &${tclibc}-${kernel}
           local_conf:
@@ -79,9 +81,10 @@ jobs:
             - INHERIT:remove = 'rm_work'
             - TCLIBC := '${tclibc}'
             - PREFERRED_PROVIDER_virtual/kernel := 'linux-${kernel}'
-            - INITRAMFS_IMAGE ?= 'initramfs-rootfs-image'
+            - INITRAMFS_IMAGE := '${initramfs}'
 
         EOF
+        done
         done
         done
 


### PR DESCRIPTION
Enable building of the images with and without initramfs so that all possible dependencies between the kernel and the initramfs are covered.