### PR TITLE
CI: revert meta-oe/meta-python enablement 

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -28,7 +28,6 @@ on:
 
 env:
   POKY_URL: https://git.yoctoproject.org/poky
-  META_OE_URL: https://github.com/openembedded/meta-openembedded
   DISTRO: poky
   TCLIBC: glibc musl
   KERNELS: linaro-qcomlt yocto
@@ -59,14 +58,12 @@ jobs:
             git_trees:
               - branch: ${{inputs.branch}}
                 url: $POKY_URL
-              - branch: ${{inputs.branch}}
-                url: $META_OE_URL
               - ${{inputs.ref_type}}: ${{inputs.ref}}
                 url: ${{inputs.url}}
           distro: $DISTRO
           target: ${{inputs.images}}
           bblayers_conf:
-            - BBLAYERS += '../$(echo ${{github.repository}} | cut -d'/' -f2) ../meta-openembedded/meta-oe ../meta-openembedded/meta-python'
+            - BBLAYERS += '../$(echo ${{github.repository}} | cut -d'/' -f2)'
           artifacts: []
         EOF
 


### PR DESCRIPTION
This reverts commits 3a3204a ("CI: also enable meta-python") and
d208627 ("CI: temporarily add meta-oe to the setup"). Enabling
meta-oe and meta-python results in a lot of issues. Build dependencies
of esp-qcom-image will be handled in a different way