### PR TITLE
conf: machine: qcom-armv8a: add QCOM_BOOTIMG_ROOTFS for qcs6490-rb3gen2

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -36,6 +36,7 @@ QCOM_BOOTIMG_ROOTFS[sm8450-hdk] ?= "PARTLABEL=userdata"
 QCOM_BOOTIMG_ROOTFS[qcs404-evb-4000] ?= "/dev/mmcblk0p27"
 QCOM_BOOTIMG_ROOTFS[qrb2210-rb1] ?= "PARTLABEL=userdata"
 QCOM_BOOTIMG_ROOTFS[qrb4210-rb2] ?= "PARTLABEL=userdata"
+QCOM_BOOTIMG_ROOTFS[qcs6490-rb3gen2] ?= "PARTLABEL=system"
 SD_QCOM_BOOTIMG_ROOTFS[apq8016-sbc] ?= "/dev/mmcblk1p7"
 KERNEL_CMDLINE_EXTRA[sdm845-db845c] ?= "clk_ignore_unused pd_ignore_unused"
 


### PR DESCRIPTION
Hi,

Small patch to fix QCOM_BOOTIMG_ROOTFS for qcs6490-rb3gen2.

Thanks & Regards,
Tommaso