### PR TITLE
python3-pefile: vendor in the recipe

### DIFF
--- a/recipes-vendor-in/python/python3-pefile/run-ptest
+++ b/recipes-vendor-in/python/python3-pefile/run-ptest
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pytest --automake --ignore=./tests/pefile_test.py

--- a/recipes-vendor-in/python/python3-pefile_2024.8.26.bb
+++ b/recipes-vendor-in/python/python3-pefile_2024.8.26.bb
@@ -1,0 +1,28 @@
+SUMMARY = "Python PE parsing module"
+DESCRIPTION = "A multi-platform Python module to parse and work with Portable Executable (PE) files."
+HOMEPAGE = "https://github.com/erocarrera/pefile"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e34c75178086aca0a17551ffbacaca53"
+
+inherit setuptools3 ptest
+SRCREV = "4b3b1e2e568a88d4f1897d694d684f23d9e270c4"
+SRC_URI = "git://github.com/erocarrera/pefile;branch=master;protocol=https \
+           file://run-ptest"
+S = "${WORKDIR}/git"
+
+BBCLASSEXTEND = "native nativesdk"
+
+do_install_ptest() {
+   install -d ${D}${PTEST_PATH}/tests
+   cp -rf ${S}/tests/* ${D}${PTEST_PATH}/tests/
+}
+
+RDEPENDS:${PN} += " \
+    python3-mmap \
+    python3-netclient \
+    python3-stringold \
+"
+RDEPENDS:${PN}-ptest += "\
+    python3-pytest \
+    python3-unittest-automake-output \
+"


### PR DESCRIPTION
Vendor the recipe from meta-oe. This allows us to build the esp-qcom-image without adding dependency on the meta-oe. Python-pefile should be moved from meta-oe to OE-Core, then this recipe can be dropped.

Suggestd-by: Ricardo Salveti <ricardo@foundries.io>