### PR TITLE
meta-qcom: initial u-boot support

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -6,6 +6,8 @@ MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth ext2"
 # UFS partitions in 820/845/RB5 setup with 4096 logical sector size
 EXTRA_IMAGECMD:ext4 += " -b 4096 "
 
+PREFERRED_PROVIDER_virtual/bootloader ??= "u-boot-qcom"
+
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto"
 
 # Support for dragonboard{410, 820, 845}c, rb5

--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -8,6 +8,10 @@ EXTRA_IMAGECMD:ext4 += " -b 4096 "
 
 PREFERRED_PROVIDER_virtual/bootloader ??= "u-boot-qcom"
 
+UBOOT_CONFIG ??= "qcs6490-rb3gen2 sdm845-db845c"
+UBOOT_CONFIG[qcs6490-rb3gen2] = "qcm6490_defconfig"
+UBOOT_CONFIG[sdm845-db845c] = "qcom_defconfig"
+
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto"
 
 # Support for dragonboard{410, 820, 845}c, rb5

--- a/recipes-bsp/u-boot/u-boot-qcom-common_2024.10.inc
+++ b/recipes-bsp/u-boot/u-boot-qcom-common_2024.10.inc
@@ -1,0 +1,12 @@
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"
+
+DEPENDS += "flex-native bison-native"
+
+SRC_URI = "git://git.codelinaro.org/linaro/qcomlt/u-boot.git;branch=${SRCBRANCH};protocol=https"
+
+SRCREV = "bea334ce7578d4cb645cf22d423ec11271feecfe"
+SRCBRANCH = "caleb/rbx-integration"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"

--- a/recipes-bsp/u-boot/u-boot-qcom_git.bb
+++ b/recipes-bsp/u-boot/u-boot-qcom_git.bb
@@ -1,0 +1,37 @@
+SUMMARY = "U-Boot bootloader with support for Qualcom Computer on Modules"
+HOMEPAGE = "https://git.codelinaro.org/linaro/qcomlt/u-boot"
+SECTION = "bootloaders"
+
+DESCRIPTION = "U-Boot based on mainline U-Boot used by Qualcomm BSP in \
+order to provide support for some backported features and fixes, or because it \
+was submitted for revision and it takes some time to become part of a stable \
+version, or because it is not applicable for upstreaming."
+
+BASEPV = "2024.10"
+PV = "${BASEPV}+git${SRCPV}"
+
+require recipes-bsp/u-boot/u-boot.inc
+require u-boot-qcom-common_${BASEPV}.inc
+
+DEPENDS += " \
+    xxd-native \
+    dtc-native \
+    qtestsign-native\
+"
+
+PROVIDES += "u-boot"
+
+B = "${WORKDIR}/build"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "(qcom-armv8a)"
+
+do_compile:append() {
+    export CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1
+    qtestsign -v6 aboot -o ${B}/qcm6490_defconfig/u-boot.mbn ${B}/qcm6490_defconfig/u-boot.elf
+}
+
+do_deploy:append() {
+    cp -r ${B}/qcm6490_defconfig/u-boot.mbn ${DEPLOYDIR}/u-boot-qcs6490-rb3gen2.mbn
+    cp -r ${B}/qcm6490_defconfig/u-boot.elf ${DEPLOYDIR}/u-boot-qcs6490-rb3gen2.elf
+}

--- a/recipes-devtools/qtestsign/qtestsign_git.bb
+++ b/recipes-devtools/qtestsign/qtestsign_git.bb
@@ -1,0 +1,32 @@
+SUMMARY = "qtestsign is a simple tool to sign ELF Qualcomm firmware images"
+HOMEPAGE = "https://github.com/msm8916-mainline/qtestsign"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+SRC_URI = "git://github.com/msm8916-mainline/qtestsign.git;branch=main;protocol=https"
+SRCREV = "ce6ba20f4ead008e5b522a81179c98dd48ccf06e"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+S = "${WORKDIR}/git"
+
+inherit python3native
+
+do_install() {
+    install -d ${D}${bindir}
+    install -d ${D}${PYTHON_SITEPACKAGES_DIR}/qtestsign
+
+    cd ${S}
+    cp -r * ${D}${PYTHON_SITEPACKAGES_DIR}/qtestsign
+
+    rm ${D}${PYTHON_SITEPACKAGES_DIR}/qtestsign/README.md
+    rm ${D}${PYTHON_SITEPACKAGES_DIR}/qtestsign/COPYING
+    rm ${D}${PYTHON_SITEPACKAGES_DIR}/qtestsign/requirements.txt
+
+    ln -sr ${D}${PYTHON_SITEPACKAGES_DIR}/qtestsign/qtestsign.py ${D}${bindir}/qtestsign
+}
+
+FILES:${PN} += "${PYTHON_SITEPACKAGES_DIR}/qtestsign"
+RDEPENDS:${PN} = "python3 python3-cryptography"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Hi,

This patchset add the initial support for u-boot-qcom.
This has been tested on rb3gen2 board:

Flashing the image using fastboot:
```
fastboot flash uefi_a ./u-boot-qcs6490-rb3gen2.mbn
```

Below some logs from the test.
```
U-Boot 2024.10-rc4-00620-ga61af132fb90 (Sep 09 2024 - 10:00:06 +0000)

Model: Qualcomm Technologies, Inc. Robotics RB3gen2
DRAM:  6 GiB (effective 5.9 GiB)
serial_msm_geni serial@994000: pinctrl_select_state_full: uclass_get_device_by_phandle_id: err=-19
serial_msm_geni serial@994000: pinctrl_select_state_full: uclass_get_device_by_phandle_id: err=-19
Core:  57 devices, 28 uclasses, devicetree: board

Loading Environment from nowhere... OK
In:    serial,button-kbd
Out:   serial,vidconsole
Err:   serial,vidconsole
qcom-ufshcd ufs@1d84000: Qcom UFS HC version: 4.3.0
qcom-ufshcd ufs@1d84000: [RX, TX]: gear=[3, 3], lane[2, 2], pwr[FAST MODE, FAST MODE], rate = 2
QCOM-FMP: Failed to find boot partition
Net:   No ethernet found.

scanning bus for devices...
  Device 0: (0:0) Vendor: SAMSUNG Prod.: KM2L9001CM-B518 Rev: 0700
            Type: Hard Disk
            Capacity: 118871.9 MB = 116.0 GB (30431231 x 4096)
  Device 1: (0:1) Vendor: SAMSUNG Prod.: KM2L9001CM-B518 Rev: 0700
            Type: Hard Disk
            Capacity: 7.9 MB = 0.0 GB (2047 x 4096)
  Device 2: (0:2) Vendor: SAMSUNG Prod.: KM2L9001CM-B518 Rev: 0700
            Type: Hard Disk
            Capacity: 7.9 MB = 0.0 GB (2047 x 4096)
  Device 3: (0:3) Vendor: SAMSUNG Prod.: KM2L9001CM-B518 Rev: 0700
            Type: Hard Disk
            Capacity: 31.9 MB = 0.0 GB (8191 x 4096)
  Device 4: (0:4) Vendor: SAMSUNG Prod.: KM2L9001CM-B518 Rev: 0700
            Type: Hard Disk
            Capacity: 3071.9 MB = 2.9 GB (786431 x 4096)
  Device 5: (0:5) Vendor: SAMSUNG Prod.: KM2L9001CM-B518 Rev: 0700
            Type: Hard Disk
            Capacity: 31.9 MB = 0.0 GB (8191 x 4096)
starting USB...
Bus usb@a600000: Register 2000340 NbrPorts 2
Starting the controller
USB XHCI 1.10
scanning bus usb@a600000 for devices... 1 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:  0 
=> <INTERRUPT>
```

Some references:
 - https://www.linaro.org/blog/initial-u-boot-release-for-qualcomm-platforms/

Thanks & Regards,
Tommaso