### PR TITLE
CI: drop initramfs assignment in -noinitramfs case

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -87,7 +87,6 @@ jobs:
             - INHERIT:remove = 'rm_work'
             - TCLIBC := '${tclibc}'
             - PREFERRED_PROVIDER_virtual/kernel := 'linux-${kernel}'
-            - INITRAMFS_IMAGE ?= ''
 
         EOF
         done


### PR DESCRIPTION
The kernel.bbclass already contains default assignment, drop the manual assignment of the INITRAMFS_IMAGE variable to the empty string in the CI setup.