### PR TITLE
CI: retain only licenses as build artifacts

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -67,7 +67,7 @@ jobs:
           target: ${{inputs.images}}
           bblayers_conf:
             - BBLAYERS += '../$(echo ${{github.repository}} | cut -d'/' -f2)'
-          artifacts: []
+          artifacts: ["licenses"]
         EOF
 
         for tclibc in ${TCLIBC}; do

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,7 +9,7 @@ jobs:
     uses: ./.github/workflows/build-template.yml
     with:
       host: debian-bookworm
-      images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-rootfs-image cryptodev-module esp-qcom-image
+      images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-firmware-mega-image initramfs-rootfs-image cryptodev-module esp-qcom-image
       machines: qcom-armv8a qcom-armv7a-modem qcom-armv7a
       variants: >-
         qcom-armv8a-glibc-yocto qcom-armv8a-musl-yocto

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -8,7 +8,7 @@ jobs:
     uses: ./.github/workflows/build-template.yml
     with:
       host: debian-bookworm
-      images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-rootfs-image cryptodev-module esp-qcom-image
+      images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-firmware-mega-image initramfs-rootfs-image cryptodev-module esp-qcom-image
       machines: qcom-armv8a qcom-armv7a-modem qcom-armv7a
       variants: >-
         qcom-armv8a-glibc-yocto qcom-armv8a-musl-yocto

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/build-template.yml
     with:
       host: debian-bookworm
-      images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-rootfs-image cryptodev-module
+      images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-firmware-mega-image initramfs-rootfs-image cryptodev-module
       machines: qcom-armv8a qcom-armv7a-modem qcom-armv7a
       variants: >-
         qcom-armv8a-glibc-yocto qcom-armv8a-musl-yocto


### PR DESCRIPTION
There is little point in retaining full set of build artifacts for the test builds, which is what the empty "artifacts" config does. Keep just the licences and throw away everything else.