### PR TITLE
linux-qcom-uki.bb: Initialize INITRAMFS_IMAGE to stop breaking builds

### DIFF
--- a/recipes-kernel/images/linux-qcom-uki.bb
+++ b/recipes-kernel/images/linux-qcom-uki.bb
@@ -18,6 +18,8 @@ require conf/image-uefi.conf
 
 KERNEL_VERSION = "${@get_kernelversion_file('${STAGING_KERNEL_BUILDDIR}')}"
 
+INITRAMFS_IMAGE ?= ''
+
 do_configure[depends] += " \
     systemd-boot:do_deploy \
     virtual/kernel:do_deploy \


### PR DESCRIPTION
Below error seen when INITRAMFS_IMAGE is undefined. Fix it by defining INITRAMFS_IMAGE with a weak assignment.

ERROR: Error for linux-qcom-uki.bb:do_configure[depends], dependency '${@ '${INITRAMFS_IMAGE}:do_image_complete' if d.getVar('INITRAMFS_IMAGE') else ''}' does not contain exactly one ':' character. Task 'depends' should be specified in the form 'packagename:task'

Signed-off-by: Viswanath Kraleti <quic_vkraleti@quicinc.com>
(cherry picked from commit 2de73afc76249027916accd9a83a6e66fa85a4dd)