### PR TITLE
Don't list 'Image' multiple times in KERNEL_IMAGETYPES

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -58,6 +58,3 @@ EFI_LINUX_IMG_DTB ?= ""
 
 # Place dtb at EFIDTDIR to seamlessly package
 KERNEL_DTBDEST = "${EFI_DTB_DIR}"
-
-# UKI generation needs uncompressed Kernel image
-KERNEL_IMAGETYPES:append = " Image"

--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -16,6 +16,10 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto"
 
 # Support for dragonboard{410, 820, 845}c, rb5
 KERNEL_IMAGETYPE ?= "Image.gz"
+
+# UKI generation needs uncompressed Kernel image
+KERNEL_IMAGETYPES = "Image"
+
 SERIAL_CONSOLE ?= "115200 ttyMSM0"
 KERNEL_DEVICETREE ?= " \
     qcom/apq8016-sbc.dtb \


### PR DESCRIPTION
Listing 'Image' multiple times in KERNEL_IMAGETYPES list leads to fatal QA errors while packaging [packages-list]. Using += operator instead of :append to add to list helps to avoid duplication.