### PR TITLE
switch to linux-firmware-ath10k-wcn3990

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-bsp/packagegroups/packagegroup-firmware-ecs-liva-qc710.bb
+++ b/dynamic-layers/openembedded-layer/recipes-bsp/packagegroups/packagegroup-firmware-ecs-liva-qc710.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-ecs-liva-qc710-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-ecs-liva-qc710-wifi', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-ecs-liva-qc710-wifi', '', d)} \
     firmware-qcom-ecs-liva-qc710 \
     linux-firmware-qcom-ecs-liva-qc710-audio \
     linux-firmware-qcom-ecs-liva-qc710-compute \

--- a/dynamic-layers/openembedded-layer/recipes-bsp/packagegroups/packagegroup-firmware-lenovo-miix-630.bb
+++ b/dynamic-layers/openembedded-layer/recipes-bsp/packagegroups/packagegroup-firmware-lenovo-miix-630.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-lenovo-miix-630-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990', '', d)} \
     firmware-qcom-lenovo-miix-630 \
     linux-firmware-qcom-lenovo-miix-630-audio \
     linux-firmware-qcom-lenovo-miix-630-ipa \

--- a/dynamic-layers/openembedded-layer/recipes-bsp/packagegroups/packagegroup-firmware-lenovo-yoga-c630.bb
+++ b/dynamic-layers/openembedded-layer/recipes-bsp/packagegroups/packagegroup-firmware-lenovo-yoga-c630.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-lenovo-yoga-c630-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990', '', d)} \
     firmware-qcom-lenovo-yoga-c630 \
     linux-firmware-qcom-lenovo-yoga-c630-audio \
     linux-firmware-qcom-lenovo-yoga-c630-compute \

--- a/dynamic-layers/openembedded-layer/recipes-bsp/packagegroups/packagegroup-firmware-sc8180x.bb
+++ b/dynamic-layers/openembedded-layer/recipes-bsp/packagegroups/packagegroup-firmware-sc8180x.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a640 linux-firmware-qcom-sc8180x-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990', '', d)} \
     firmware-qcom-sc8180x \
     linux-firmware-qcom-sc8180x-audio \
     linux-firmware-qcom-sc8180x-compute \

--- a/recipes-bsp/images/initramfs-firmware-ifc6560-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-ifc6560-image.bb
@@ -10,7 +10,7 @@ BAD_RECOMMENDATIONS = "\
     linux-firmware-qcom-sda660-modem \
     linux-firmware-qcom-sda660-venus \
     linux-firmware-qca \
-    linux-firmware-ath10k \
+    linux-firmware-ath10k-wcn3990 \
 "
 
 require initramfs-firmware-image.inc

--- a/recipes-bsp/images/initramfs-firmware-pixel3-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-pixel3-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with Pixel 3 firmware files"
 
 PACKAGE_INSTALL += " \
-    linux-firmware-ath10k \
+    linux-firmware-ath10k-wcn3990 \
     linux-firmware-qca \
     firmware-qcom-pixel3 \
 "

--- a/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard845c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard845c.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     firmware-qcom-dragonboard845c \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-sdm845-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-sdm845-modem', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-sdm845-modem', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca linux-firmware-qcom-sdm845-modem', '', d)} \
     linux-firmware-qcom-sdm845-audio \
     linux-firmware-qcom-sdm845-compute \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-ifc6560.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-ifc6560.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530 linux-firmware-qcom-sda660-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990', '', d)} \
     firmware-qcom-ifc6560 \
     linux-firmware-qcom-sda660-audio \
     linux-firmware-qcom-sda660-compute \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb1.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb1.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     firmware-qcom-rb1 \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qcm2290-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-qcm2290-wifi ', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-qcm2290-wifi ', '', d)} \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-qcm2290-audio \
     linux-firmware-qcom-qcm2290-modem \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb2.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb2.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     firmware-qcom-rb2 \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-qrb4210-adreno', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-qrb4210-wifi', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-qrb4210-wifi', '', d)} \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-qrb4210-audio \
     linux-firmware-qcom-qrb4210-compute \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8150-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8150-hdk.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a640 linux-firmware-qcom-sm8150-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990', '', d)} \
     firmware-qcom-sm8150-hdk \
     linux-firmware-qcom-sm8150-audio \
     linux-firmware-qcom-sm8150-compute \

--- a/recipes-bsp/packagegroups/packagegroup-firmware-sm8650-hdk.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-sm8650-hdk.bb
@@ -9,6 +9,7 @@ RRECOMMENDS:${PN} += " \
     firmware-qcom-sm8650-hdk \
     linux-firmware-lt9611uxc \
     linux-firmware-qcom-sm8650-audio \
+    linux-firmware-qcom-sm8650-audio-tplg \
     linux-firmware-qcom-sm8650-compute \
     linux-firmware-qcom-sm8650-ipa \
 "


### PR DESCRIPTION
Now as there is a separate package providing just WCN3990 data, stop
pulling the big ath10k firmware package and install just the required
data.