### PR TITLE
linux-qcom-uki: KERNEL_IMAGETYPES should be fully populated before use

### DIFF
--- a/recipes-kernel/images/linux-qcom-uki.bb
+++ b/recipes-kernel/images/linux-qcom-uki.bb
@@ -20,6 +20,21 @@ KERNEL_VERSION = "${@get_kernelversion_file('${STAGING_KERNEL_BUILDDIR}')}"
 
 INITRAMFS_IMAGE ?= ''
 
+# This recipe is skipped based on KERNEL_IMAGETYPES. However the list of kernel type can also be set with
+# KERNEL_IMAGETYPE or KERNEL_ALT_IMAGETYPE.
+# We need to combine them all to be correct (like it's done in kernel.bbclass)
+python __anonymous () {
+    # Merge KERNEL_IMAGETYPE and KERNEL_ALT_IMAGETYPE into KERNEL_IMAGETYPES
+    type = d.getVar('KERNEL_IMAGETYPE') or ""
+    alttype = d.getVar('KERNEL_ALT_IMAGETYPE') or ""
+    types = d.getVar('KERNEL_IMAGETYPES') or ""
+    if type not in types.split():
+        types = (type + ' ' + types).strip()
+    if alttype not in types.split():
+        types = (alttype + ' ' + types).strip()
+    d.setVar('KERNEL_IMAGETYPES', types)
+}
+
 do_configure[depends] += " \
     systemd-boot:do_deploy \
     virtual/kernel:do_deploy \


### PR DESCRIPTION
In response to https://github.com/quic-yocto/meta-qcom-hwe/pull/42.

KERNEL_IMAGETYPES is not enough to be checked, since kernel types can also be set using KERNEL_IMAGETYPE or KERNEL_ALT_IMAGETYPE. Like it's done in OE-core kernel class, we need to combine all these variables.