### PR TITLE
Fix HDMI 4k output on Qualcomm Robotics RB3 Platform

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-graphics/images/qcom-x11-image.bb
+++ b/dynamic-layers/openembedded-layer/recipes-graphics/images/qcom-x11-image.bb
@@ -27,4 +27,5 @@ CORE_IMAGE_BASE_INSTALL += " \
     mesa-demos \
     openbox \
     rsync \
+    xrandr --output HDMI-1 --mode 3840x2160 --rate 30 \
 "

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
@@ -18,6 +18,7 @@ do_install() {
     install -d ${D}${FW_QCOM_PATH}
 
     install -m 0444 ./08-dspso/dspso.bin ${D}${FW_QCOM_PATH}
+    install -m 0444 ./4k-support/4k-support.bin ${D}${FW_QCOM_PATH}
 
     install -m 0444 ./17-USB3-201-202-FW/K2026090.mem ${D}${nonarch_base_libdir}/firmware/renesas_usb_fw.mem
 

--- a/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard845c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard845c.bb
@@ -10,4 +10,6 @@ RRECOMMENDS:${PN} += " \
     linux-firmware-qcom-sdm845-audio \
     linux-firmware-qcom-sdm845-compute \
     linux-firmware-qcom-venus-5.2 \
+    linux-firmware-qcom-sdm845-hdmi \
+    linux-firmware-qcom-sdm845-4k \
 "


### PR DESCRIPTION
Related to #110

Add support for 4k resolution output on Qualcomm Robotics RB3 Platform (SDA845).

* Update `recipes-bsp/packagegroups/packagegroup-firmware-dragonboard845c.bb` to include `linux-firmware-qcom-sdm845-hdmi` and `linux-firmware-qcom-sdm845-4k`.
* Update `recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb` to add `4k-support.bin` to the `do_install` function.
* Update `dynamic-layers/openembedded-layer/recipes-graphics/images/qcom-x11-image.bb` to add `xrandr --output HDMI-1 --mode 3840x2160 --rate 30` to `CORE_IMAGE_BASE_INSTALL`.

