### PR TITLE
CI: manually specify build matrix

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -10,6 +10,14 @@ jobs:
       host: ubuntu-20.04
       images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-rootfs-image cryptodev-module
       machines: dragonboard-410c dragonboard-845c qrb5165-rb5 qcom-armv8a sdx55-mtp sa8155p-adp qcom-armv7a
+      variants: >-
+        dragonboard-410c-glibc-linaro-qcomlt dragonboard-410c-musl-linaro-qcomlt
+        dragonboard-845c-glibc-linaro-qcomlt dragonboard-845c-musl-linaro-qcomlt
+        qrb5165-rb5-glibc-linaro-qcomlt qrb5165-rb5-musl-linaro-qcomlt
+        qcom-armv8a-glibc-linaro-qcomlt qcom-armv8a-musl-linaro-qcomlt
+        sdx55-mtp-glibc-linaro-qcomlt sdx55-mtp-musl-linaro-qcomlt
+        sa8155p-adp-glibc-linaro-qcomlt sa8155p-adp-musl-linaro-qcomlt
+        qcom-armv7a-glibc-linaro-qcomlt qcom-armv7a-musl-linaro-qcomlt
       ref: refs/pull/${{github.event.pull_request.number}}/merge
       branch: ${{github.base_ref}}
       url: ${{github.server_url}}/${{github.repository}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,6 +12,14 @@ jobs:
       host: ubuntu-20.04
       images: core-image-base core-image-weston core-image-x11 initramfs-test-image initramfs-test-full-image initramfs-firmware-image initramfs-rootfs-image cryptodev-module
       machines: dragonboard-410c dragonboard-845c qrb5165-rb5 qcom-armv8a sdx55-mtp sa8155p-adp qcom-armv7a
+      variants: >-
+        dragonboard-410c-glibc-linaro-qcomlt dragonboard-410c-musl-linaro-qcomlt
+        dragonboard-845c-glibc-linaro-qcomlt dragonboard-845c-musl-linaro-qcomlt
+        qrb5165-rb5-glibc-linaro-qcomlt qrb5165-rb5-musl-linaro-qcomlt
+        qcom-armv8a-glibc-linaro-qcomlt qcom-armv8a-musl-linaro-qcomlt
+        sdx55-mtp-glibc-linaro-qcomlt sdx55-mtp-musl-linaro-qcomlt
+        sa8155p-adp-glibc-linaro-qcomlt sa8155p-adp-musl-linaro-qcomlt
+        qcom-armv7a-glibc-linaro-qcomlt qcom-armv7a-musl-linaro-qcomlt
       ref: ${{github.sha}}
       ref_type: sha
       branch: ${{github.ref_name}}


### PR DESCRIPTION
In order to be more flexible, manually specify build variants (machine-libc-kernel-subtype)

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
(cherry picked from commit 3c5a909a702a4ac0f97497e2e7ff33b22787e6bd)