### PR TITLE
linux-yocto: fix Signed-off-by tag

### DIFF
--- a/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0002-UPSTREAM-dt-bindings-arm-qcom-Add-QCM6490-IDP-and-QC.patch
+++ b/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0002-UPSTREAM-dt-bindings-arm-qcom-Add-QCM6490-IDP-and-QC.patch
@@ -10,7 +10,7 @@ various form factor including IoT and qcs6490-rb3gen2 based off
 qcs6490 SoC derivative of qcm6490 without internal modem.
 
 Co-developed by: Naina Mehta <quic_nainmeht@quicinc.com>
-Signed-off by: Naina Mehta <quic_nainmeht@quicinc.com>
+Signed-off-by: Naina Mehta <quic_nainmeht@quicinc.com>
 
 Signed-off-by: Komal Bajaj <quic_kbajaj@quicinc.com>
 Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>


### PR DESCRIPTION
The Signed-off-by tag in this kernel patch is bogus, as reported by the Yocto patchreview script:

Malformed Signed-off-by 'Signed-off by:' (<meta-qcom-new>/recipes-kernel/linux/linux-yocto/qcm6490-board-dts/0002-UPSTREAM-dt-bindings-arm-qcom-Add-QCM6490-IDP-and-QC.patch)