### PR TITLE
firmware-qcom-rb3gen2: fix dependency on pil-squasher

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-rb3gen2_00039.2.bb
+++ b/recipes-bsp/firmware/firmware-qcom-rb3gen2_00039.2.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://${LICENSE_FILE};md5=164e3362a538eb11d3ac51e8e134294b 
     file://${LICENSE_FILE_PDF};md5=4ceffe94cb40cdce6d2f4fb93cc063d1 \
     "
 
-DEPENDS += "qca-swiss-army-knife-native pil-squasher"
+DEPENDS += "qca-swiss-army-knife-native pil-squasher-native"
 
 FW_D_NAME = "QCM6490_fw"
 


### PR DESCRIPTION
It should be a dependency on the -native flavor, since the tool is used during the build. Interestingly it worked fine so far! That's because pil-squasher-native is already added to DEPENDS in firmware-qcom-adreno.inc.

I have decided to leave it here as well, since pil-squasher is used in this recipe too.

With pil-squasher in DEPENDS, it breaks the yocto-checklayer script with:

   allarch firmware-qcom-rb3gen2:do_prepare_recipe_sysroot: a4777557300156768d6ed9c776ef216d82576f103a9382c35ac6595e3008c967 (qcm6490-idp, sa8775p-ride-sx, qcs6490-rb3gen2-core-kit) != a121b24b301e93b1153c72e858cf4ced5217306d9a7c9ed51bf14c56434c1ce3 (qcom-armv7a) != 16bcafbe404dd2e0b58c4a86ca923c8760273fac69a8237008f78f3d4f9b2efe (qcom-armv7a-modem) != a5cfc0b555ce8fc4b76bfdd5a1f9c600cb9db2ac052005d43109ebe239fbd902 (qcom-armv8a)

11 tasks where not listed because some other task of the recipe already differed. It is likely that differences from different recipes also have the same root cause.

To investigate, run bitbake-diffsigs -t recipename taskname -s fromsig tosig. Example: (qcom-armv7a-modem) != (qcm6490-idp, sa8775p-ride-sx, qcs6490-rb3gen2-core-kit) in the last line Command: bitbake-diffsigs -t firmware-qcom-rb3gen2 do_prepare_recipe_sysroot -s 16bcafbe404dd2e0b58c4a86ca923c8760273fac69a8237008f78f3d4f9b2efe a4777557300156768d6ed9c776ef216d82576f103a9382c35ac6595e3008c967
   NOTE: Reconnecting to bitbake server...
   Hash for task dependency pil-squasher:do_populate_sysroot changed from 99a1116a1f50873ce3b8b1ab8c710b8e47fae6419feb9a7a18c2faadbf8ac7c6 to c0f327088cdd9c8eccfa4ed3835220c0fd997700de096a4bffdd060c1095990b