### PR TITLE
README: markdown syntax fix for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ support for the particular device extend the qcom-armv8a.conf file .
 
 ## Quick build
 
-If you're new to the Yocto Project, you might want to read the ![Yocto Project
+If you're new to the Yocto Project, you might want to read the [Yocto Project
 Quick Build](https://docs.yoctoproject.org/brief-yoctoprojectqs/index.html) 
 document in order to setup your Yocto Project build environment. 
 


### PR DESCRIPTION
Improved the markdown syntax in README for links and code blocks. Further, fixed the syntax of hyperlink for Yocto Project Quick Build.