### PR TITLE
Firmware for Dragonboard APQ8060

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard-apq8060.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard-apq8060.bb
@@ -1,0 +1,30 @@
+# Specify location of the corresponding NON-HLOS.bin file by adding
+# NHLOS_URI:pn-firmware-qcom-dragonboard-apq8060 = "..."  to local.conf. Use
+# "file://" if the file is provided locally.
+
+DESCRIPTION = "QCOM Firmware for Dragonboard APQ8060 board"
+
+LICENSE = "CLOSED"
+
+# dragonboard8060 firmware is unsigned, so install into generic location
+FW_QCOM_NAME = "apq8060"
+
+FW_QCOM_LIST = "q6.mbn"
+
+S = "${UNPACKDIR}"
+
+require recipes-bsp/firmware/firmware-qcom.inc
+require recipes-bsp/firmware/firmware-qcom-nhlos.inc
+
+unpack_nhlos_image:append() {
+    if [ -d ${B}/firmware/IMAGE ] ; then
+        mv ${B}/firmware/IMAGE ${B}/firmware/image
+        for file in ${B}/firmware/image/* ; do
+            mv "${file}" ${B}/firmware/image/`basename ${file} | tr A-Z a-z`
+        done
+    fi
+}
+
+SPLIT_FIRMWARE_PACKAGES = " \
+    linux-firmware-qcom-${FW_QCOM_NAME}-q6 \
+"

--- a/recipes-bsp/firmware/firmware-qcom-nhlos.inc
+++ b/recipes-bsp/firmware/firmware-qcom-nhlos.inc
@@ -13,9 +13,12 @@ DEPENDS += "pil-squasher-native mtools-native"
 # script to let base.bbclass to pick up dependencies
 SRC_URI += "${NHLOS_URI}"
 
-handle_nonhlos_image() {
+unpack_nhlos_image() {
     mkdir -p ${B}/firmware
     mcopy -n -s -i "$1" ::/* ${B}/firmware/
+}
+
+handle_nonhlos_image() {
     for fw in ${B}/firmware/image/*.mdt ; do
         pil-squasher ${B}/`basename $fw mdt`mbn $fw || exit 1
     done
@@ -36,7 +39,8 @@ do_compile:prepend() {
     if [ -z "${NHLOS_URI}" ] ; then
         bbwarn "${PN}: not packaging NHLOS firmware. Please provide HNLOS_URI"
     else
-        handle_nonhlos_image ${UNPACKDIR}/${@get_nhlos_path(d.getVar("NHLOS_URI"))}
+        unpack_nhlos_image ${UNPACKDIR}/${@get_nhlos_path(d.getVar("NHLOS_URI"))}
+        handle_nonhlos_image
     fi
 }
 


### PR DESCRIPTION
Add recipe for packaging firmware for Dragonboard APQ8060, the oldest Qualcomm board supported by the Linux kernel.